### PR TITLE
stops streams by setting `src` attribute to the empty string

### DIFF
--- a/addon/hifi-connections/native-audio.js
+++ b/addon/hifi-connections/native-audio.js
@@ -193,7 +193,9 @@ let Sound = BaseSound.extend({
   stop() {
     let audio = this.get('audio');
     audio.pause();
-    audio.removeAttribute('src');
+    // must explicitly set it to the empty string or else the browser will
+    // continue to download
+    audio.setAttribute('src', '');
   },
 
   willDestroy() {

--- a/tests/unit/hifi-connections/native-audio-test.js
+++ b/tests/unit/hifi-connections/native-audio-test.js
@@ -60,6 +60,11 @@ test("If it's a stream, we stop on pause", function(assert) {
   assert.equal(sound.get('audio').src, goodUrl, "audio src attribute is set");
 
   sound.stop();
-  assert.equal(sound.get('audio').src, "", "audio src attribute is not set");
+  // audio elements need their src attribute explicitly set to the empty string
+  // to stop downloading a stream, i.e. setAttribute('src', '').
+  // an attribute cleared with removeAttribute will return null when accessed
+  // with getAttribute so we use the DOM api here to verify that it's the
+  // empty string.
+  assert.equal(sound.get('audio').getAttribute('src'), "", "audio src attribute is set to the empty string");
   assert.equal(stopSpy.callCount, 1, "stop was called");
 });


### PR DESCRIPTION
rather than removing it. for whatever reason browsers seem to respond to
an empty string better than an removed attribute.

closes #7