### PR TITLE
allow consumers to specify a mime type for particular URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ The files created by the blueprint should walk you through what you need to impl
       // Do any global setup needed for your third party library.
     },
 
-    canPlayExtension(/* extension */) {
-      // check if connection can play file with this extension
+    canPlayMimeType(/* extension */) {
+      // check if connection can play file with this mime type
       return true;
     },
 
@@ -191,7 +191,7 @@ The files created by the blueprint should walk you through what you need to impl
   });
 ```
 
-`canPlayExtension` and `canUseConnection` are called when `hifi` is looking for connections to try with a url. Give your best guess here. For instance, our built-in HLS.js library won't work on mobile, so `canUseConnection` returns false on a mobile device and true on a desktop browser. Similary, HLS only plays `.m3u8` files, so we just check for that extension in `canPlayExtension`.
+`canPlayMimeType` and `canUseConnection` are called when `hifi` is looking for connections to try with a url. Give your best guess here. For instance, our built-in HLS.js library won't work on mobile, so `canUseConnection` returns false on a mobile device and true on a desktop browser. Similary, HLS only plays `application/vnd.apple.mpegurl` files, so we just check for that extension in `canPlayMimeType`.
 
 ##### Implement methods to bridge communication between hifi and your third party sound.
 

--- a/addon/hifi-connections/base.js
+++ b/addon/hifi-connections/base.js
@@ -11,8 +11,16 @@ let ClassMethods = Ember.Mixin.create({
   },
 
   canPlay(url) {
-    let urlExtension = url.split('.').pop().split('?').shift().split('#').shift();
-    return this.canUseConnection(url) && this.canPlayExtension(urlExtension);
+    if (typeof url === 'string') {
+      let urlExtension = url.split('.').pop().split('?').shift().split('#').shift();
+      return this.canUseConnection(url) && this.canPlayExtension(urlExtension);
+    }
+    else if (url.mimeType) {
+      return this.canPlayMimeType(url.mimeType);
+    }
+    else {
+      throw new Error('URL must be a string or object with a mimeType property');
+    }
   },
 
   canUseConnection() {
@@ -28,6 +36,21 @@ let ClassMethods = Ember.Mixin.create({
     }
     else if (blackList){
       return !Ember.A(blackList).contains(extension);
+    }
+    else {
+      return true; // assume true
+    }
+  },
+  
+  canPlayMimeType(mimeType) {
+    let mimeTypeWhiteList = this.mimeTypeWhiteList;
+    let mimeTypeBlackList = this.mimeTypeBlackList;
+
+    if (mimeTypeWhiteList) {
+      return Ember.A(mimeTypeWhiteList).contains(mimeType);
+    }
+    else if (mimeTypeBlackList){
+      return !Ember.A(mimeTypeBlackList).contains(mimeType);
     }
     else {
       return true; // assume true

--- a/addon/hifi-connections/dummy-connection.js
+++ b/addon/hifi-connections/dummy-connection.js
@@ -4,7 +4,7 @@ let ClassMethods = Ember.Mixin.create({
   setup() {},
   canPlay: () => true,
   canUseConnection: () => true,
-  canPlayExtension: () => true,
+  canPlayMimeType: () => true,
 });
 
 let DummyConnection = Ember.Object.extend(Ember.Evented, {

--- a/addon/hifi-connections/hls.js
+++ b/addon/hifi-connections/hls.js
@@ -3,8 +3,7 @@ import BaseSound from './base';
 import HLS from 'hls';
 
 let ClassMethods = Ember.Mixin.create({
-  extensionWhiteList: ['m3u8'],
-  mimeTypeWhiteList:  ['application/vnd.apple.mpegurl'],
+  acceptMimeTypes:  ['application/vnd.apple.mpegurl'],
 
   canUseConnection(/* audioUrl */) {
     // We basically never want to use this on a mobile device

--- a/addon/hifi-connections/hls.js
+++ b/addon/hifi-connections/hls.js
@@ -4,6 +4,7 @@ import HLS from 'hls';
 
 let ClassMethods = Ember.Mixin.create({
   extensionWhiteList: ['m3u8'],
+  mimeTypeWhiteList:  ['application/vnd.apple.mpegurl'],
 
   canUseConnection(/* audioUrl */) {
     // We basically never want to use this on a mobile device

--- a/addon/hifi-connections/howler.js
+++ b/addon/hifi-connections/howler.js
@@ -3,8 +3,7 @@ import BaseSound from './base';
 import { Howl } from 'howler';
 
 let ClassMethods = Ember.Mixin.create({
-  extensionBlackList: ['m3u8'],
-  mimeTypeBlackList:  ['application/vnd.apple.mpegurl'],
+  rejectMimeTypes:  ['application/vnd.apple.mpegurl'],
 
   toString() {
     return 'Howler';

--- a/addon/hifi-connections/howler.js
+++ b/addon/hifi-connections/howler.js
@@ -4,6 +4,7 @@ import { Howl } from 'howler';
 
 let ClassMethods = Ember.Mixin.create({
   extensionBlackList: ['m3u8'],
+  mimeTypeBlackList:  ['application/vnd.apple.mpegurl'],
 
   toString() {
     return 'Howler';

--- a/addon/hifi-connections/native-audio.js
+++ b/addon/hifi-connections/native-audio.js
@@ -2,15 +2,6 @@ import Ember from 'ember';
 import BaseSound from './base';
 
 let ClassMethods = Ember.Mixin.create({
-  canPlayExtension(extension) {
-    if (Ember.A(['m3u8', 'm3u']).contains(extension)) {
-      return this.canPlayMimeType('audio/mpeg');
-    }
-    else {
-      return this.canPlayMimeType(`audio/${extension}`);
-    }
-  },
-
   canPlayMimeType(mimeType) {
     let audio = new Audio();
     // it returns "probably" and "maybe". Both are worth trying. Empty is bad.

--- a/addon/hifi-connections/native-audio.js
+++ b/addon/hifi-connections/native-audio.js
@@ -3,15 +3,18 @@ import BaseSound from './base';
 
 let ClassMethods = Ember.Mixin.create({
   canPlayExtension(extension) {
-    let audio = new Audio();
-
     if (Ember.A(['m3u8', 'm3u']).contains(extension)) {
-      return audio.canPlayType(`audio/mpeg`) !== "";
+      return this.canPlayMimeType('audio/mpeg');
     }
     else {
-      // it returns "probably" and "maybe". Both are worth trying. Empty is bad.
-      return (audio.canPlayType(`audio/${extension}`) !== "");
+      return this.canPlayMimeType(`audio/${extension}`);
     }
+  },
+
+  canPlayMimeType(mimeType) {
+    let audio = new Audio();
+    // it returns "probably" and "maybe". Both are worth trying. Empty is bad.
+    return (audio.canPlayType(mimeType) !== "");
   },
 
   toString() {

--- a/addon/services/hifi.js
+++ b/addon/services/hifi.js
@@ -584,7 +584,7 @@ export default Service.extend(Ember.Evented, {
           strategies.push({
             connectionName:  name,
             connection:      connection,
-            url:             url
+            url:             url.url || url
           });
         }
       });

--- a/addon/utils/mime-types.js
+++ b/addon/utils/mime-types.js
@@ -1,0 +1,230 @@
+// we are only concerned with a subset of all available mime types
+// data and function lifted from https://github.com/jshttp/mime-db
+const MIME_TYPES = {
+  "audio/3gpp": {
+    "source": "iana",
+    "extensions": ["3gpp"]
+  },
+  "audio/adpcm": {
+    "source": "apache",
+    "extensions": ["adp"]
+  },
+  "audio/basic": {
+    "source": "iana",
+    "compressible": false,
+    "extensions": ["au","snd"]
+  },
+  "audio/midi": {
+    "source": "apache",
+    "extensions": ["mid","midi","kar","rmi"]
+  },
+  "audio/mp3": {
+    "compressible": false,
+    "extensions": ["mp3"]
+  },
+  "audio/mp4": {
+    "source": "iana",
+    "compressible": false,
+    "extensions": ["m4a","mp4a"]
+  },
+  "audio/mpeg": {
+    "source": "iana",
+    "compressible": false,
+    "extensions": ["mpga","mp2","mp2a","mp3","m2a","m3a"]
+  },
+  "audio/ogg": {
+    "source": "iana",
+    "compressible": false,
+    "extensions": ["oga","ogg","spx"]
+  },
+  "audio/s3m": {
+    "source": "apache",
+    "extensions": ["s3m"]
+  },
+  "audio/silk": {
+    "source": "apache",
+    "extensions": ["sil"]
+  },
+  "audio/vnd.dece.audio": {
+    "source": "iana",
+    "extensions": ["uva","uvva"]
+  },
+  "audio/vnd.digital-winds": {
+    "source": "iana",
+    "extensions": ["eol"]
+  },
+  "audio/vnd.dra": {
+    "source": "iana",
+    "extensions": ["dra"]
+  },
+  "audio/vnd.dts": {
+    "source": "iana",
+    "extensions": ["dts"]
+  },
+  "audio/vnd.dts.hd": {
+    "source": "iana",
+    "extensions": ["dtshd"]
+  },
+  "audio/vnd.lucent.voice": {
+    "source": "iana",
+    "extensions": ["lvp"]
+  },
+  "audio/vnd.ms-playready.media.pya": {
+    "source": "iana",
+    "extensions": ["pya"]
+  },
+  "audio/vnd.nuera.ecelp4800": {
+    "source": "iana",
+    "extensions": ["ecelp4800"]
+  },
+  "audio/vnd.nuera.ecelp7470": {
+    "source": "iana",
+    "extensions": ["ecelp7470"]
+  },
+  "audio/vnd.nuera.ecelp9600": {
+    "source": "iana",
+    "extensions": ["ecelp9600"]
+  },
+  "audio/vnd.rip": {
+    "source": "iana",
+    "extensions": ["rip"]
+  },
+  "audio/wav": {
+    "compressible": false,
+    "extensions": ["wav"]
+  },
+  "audio/wave": {
+    "compressible": false,
+    "extensions": ["wav"]
+  },
+  "audio/webm": {
+    "source": "apache",
+    "compressible": false,
+    "extensions": ["weba"]
+  },
+  "audio/x-aac": {
+    "source": "apache",
+    "compressible": false,
+    "extensions": ["aac"]
+  },
+  "audio/x-aiff": {
+    "source": "apache",
+    "extensions": ["aif","aiff","aifc"]
+  },
+  "audio/x-caf": {
+    "source": "apache",
+    "compressible": false,
+    "extensions": ["caf"]
+  },
+  "audio/x-flac": {
+    "source": "apache",
+    "extensions": ["flac"]
+  },
+  "audio/x-m4a": {
+    "source": "nginx",
+    "extensions": ["m4a"]
+  },
+  "audio/x-matroska": {
+    "source": "apache",
+    "extensions": ["mka"]
+  },
+  "audio/x-mpegurl": {
+    "source": "apache",
+    "extensions": ["m3u"]
+  },
+  "audio/x-ms-wax": {
+    "source": "apache",
+    "extensions": ["wax"]
+  },
+  "audio/x-ms-wma": {
+    "source": "apache",
+    "extensions": ["wma"]
+  },
+  "audio/x-pn-realaudio": {
+    "source": "apache",
+    "extensions": ["ram","ra"]
+  },
+  "audio/x-pn-realaudio-plugin": {
+    "source": "apache",
+    "extensions": ["rmp"]
+  },
+  "audio/x-realaudio": {
+    "source": "nginx",
+    "extensions": ["ra"]
+  },
+  "audio/x-wav": {
+    "source": "apache",
+    "extensions": ["wav"]
+  },
+  "audio/xm": {
+    "source": "apache",
+    "extensions": ["xm"]
+  },
+  "application/vnd.apple.mpegurl": {
+    "source": "iana",
+    "extensions": ["m3u8"]
+  },
+  "audio/x-mpepgurl": {
+    "source": "apache",
+    "extensions": ["m3u"]
+  }
+};
+
+const TYPES       = Object.create(null);
+const EXTENSIONS  = Object.create(null);
+
+function populateMaps(extensions, types) {
+  // source preference (least -> most)
+  let preference = ['nginx', 'apache', undefined, 'iana'];
+
+  Object.keys(MIME_TYPES).forEach(function(type) {
+    let mime = MIME_TYPES[type];
+    let exts = mime.extensions;
+
+    if (!exts || !exts.length) {
+      return false;
+    }
+
+    // mime -> extensions
+    extensions[type] = exts;
+
+    // extension -> mime
+    for (let i = 0; i < exts.length; i++) {
+      let extension = exts[i];
+
+      if (types[extension]) {
+        let start = preference.indexOf(MIME_TYPES[types[extension]].source);
+        let end = preference.indexOf(mime.source);
+
+        if (types[extension] !== 'application/octet-stream' &&
+          start > end || (start === end && types[extension].substr(0, 12) === 'application/')) {
+          // skip the remapping
+          continue;
+        }
+      }
+
+      // set the extension -> mime
+      types[extension] = type;
+    }
+  });
+}
+
+populateMaps(EXTENSIONS, TYPES);
+
+export function getMimeType(url) {
+  if (!url || typeof url !== 'string') {
+    return false;
+  }
+  
+  let extension = url
+    .toLowerCase()
+    .split('.').pop()
+    .split('?').shift()
+    .split('#').shift();
+  
+  if (!extension) {
+    return false;
+  }
+  
+  return TYPES[extension] || false;
+}

--- a/app/utils/mime-types.js
+++ b/app/utils/mime-types.js
@@ -1,0 +1,1 @@
+export { getMimeType } from 'ember-hifi/utils/mime-types';

--- a/blueprints/hifi-connection/files/__root__/hifi-connections/__name__.js
+++ b/blueprints/hifi-connection/files/__root__/hifi-connections/__name__.js
@@ -9,8 +9,8 @@ let ClassMethods = Ember.Mixin.create({
     // Do any global setup needed for your third party library.
   },
   
-  canPlayExtension(/* extension */) {
-    // check if connection can play file with this extension
+  canPlayMimeType(/* extension */) {
+    // check if connection can play file with this mime type
     return true;
   },
 

--- a/tests/unit/hifi-connections/base-test.js
+++ b/tests/unit/hifi-connections/base-test.js
@@ -43,3 +43,8 @@ test("isPlaying gets set to false when an 'audio-stopped' event is fired", funct
 
   done();
 });
+
+test("base sound will eagerly accept unknown mime types", function(assert) {
+  let unknownMimeType = "http://www.example.come/audio";
+  assert.equal(baseSound.constructor.canPlay(unknownMimeType), true, "defaults to true if the mime type cannot be determined");
+});

--- a/tests/unit/hifi-connections/hls-test.js
+++ b/tests/unit/hifi-connections/hls-test.js
@@ -54,6 +54,28 @@ test("HLS connection should say it can play files with m3u8 extension", function
   });
 });
 
+test("HLS connection should report playability of file objects", function(assert) {
+  let goodFiles = Ember.A([
+    {url: "http://example.org/test.m3u8", mimeType: "application/vnd.apple.mpegurl"},
+  ]);
+  
+  let badFiles = Ember.A([
+    {url: "http://example.org/test.mp3", mimeType: "audio/mpeg"},
+    {url: "http://example.org/test.aac", mimeType: "audio/aac"},
+    {url: "http://example.org/test.wav", mimeType: "audio/wav"}
+  ]);
+
+  assert.expect(badFiles.length + goodFiles.length);
+
+  badFiles.forEach(url => {
+    assert.equal(HLSConnection.canPlay(url), false, `Should not play file with mime type ${url.mimeType}`);
+  });
+
+  goodFiles.forEach(url => {
+    assert.equal(HLSConnection.canPlay(url), true, `Should be able to play file with ${url.mimeType}`);
+  });
+});
+
 test("On first media error stream will attempt a retry", function(assert) {
   let sound = this.subject({url: goodUrl});
 

--- a/tests/unit/hifi-connections/howler-test.js
+++ b/tests/unit/hifi-connections/howler-test.js
@@ -53,6 +53,28 @@ test("Howler should say it cannot play hls streams", function(assert) {
   });
 });
 
+test("Howler should report playability of file objects", function(assert) {
+  let badFiles = Ember.A([
+    {url: "http://example.org/test.m3u8", mimeType: "application/vnd.apple.mpegurl"},
+  ]);
+  
+  let goodFiles = Ember.A([
+    {url: "http://example.org/test.mp3", mimeType: "audio/mpeg"},
+    {url: "http://example.org/test.aac", mimeType: "audio/aac"},
+    {url: "http://example.org/test.wav", mimeType: "audio/wav"}
+  ]);
+
+  assert.expect(badFiles.length + goodFiles.length);
+
+  badFiles.forEach(url => {
+    assert.equal(HowlerConnection.canPlay(url), false, `Should not play file with mime type ${url.mimeType}`);
+  });
+
+  goodFiles.forEach(url => {
+    assert.equal(HowlerConnection.canPlay(url), true, `Should be able to play file with ${url.mimeType}`);
+  });
+});
+
 test("If we 404, we give up", function(assert) {
   assert.expect(1);
   let done = assert.async();

--- a/tests/unit/services/hifi-test.js
+++ b/tests/unit/services/hifi-test.js
@@ -410,6 +410,29 @@ test("consumer can specify a mime type for a url", function(assert) {
   });
 });
 
+test("if a mime type cannot be determined, try to play it anyway", function(assert) {
+  const service = this.subject({ options: chooseActiveConnections('LocalDummyConnection') });
+
+  let done = assert.async();
+  let mysteryFile = "/test/sound-without-extension";
+
+  let LocalDummyConnection = get(service, `_connections.LocalDummyConnection`);
+
+  let createSpy   = sinon.stub(LocalDummyConnection, 'create', function() {
+    let sound =  DummyConnection.create(...arguments);
+    Ember.run.next(() => sound.trigger('audio-ready'));
+    return sound;
+  });
+
+  let promise = service.load(mysteryFile);
+
+  promise.then(() => {
+    assert.ok(createSpy.calledOnce, "A sound should have been created");
+    done();
+  });
+  
+});
+
 test("for desktop devices, try each url on each connection", function(assert) {
   let done = assert.async();
   let urls              = ["first-test-url.mp3", "second-test-url.mp3", "third-test-url.mp3"];

--- a/tests/unit/services/hifi-test.js
+++ b/tests/unit/services/hifi-test.js
@@ -385,6 +385,31 @@ test("consumer can specify the order of connections to be used with a some urls"
   });
 });
 
+test("consumer can specify a mime type for a url", function(assert) {
+  const service = this.subject({ options: chooseActiveConnections('LocalDummyConnection') });
+
+  let done = assert.async();
+  let fileObject = {url: "/test/sound-without-extension", mimeType: "audio/mpeg"};
+
+  let LocalDummyConnection = get(service, `_connections.LocalDummyConnection`);
+
+  let mimeTypeSpy = sinon.stub(LocalDummyConnection, 'canPlayMimeType').returns(true);
+  let createSpy   = sinon.stub(LocalDummyConnection, 'create', function() {
+    let sound =  DummyConnection.create(...arguments);
+    Ember.run.next(() => sound.trigger('audio-ready'));
+    return sound;
+  });
+
+  let promise = service.load(fileObject);
+
+  promise.then(() => {
+    assert.ok(mimeTypeSpy.calledOnce, "local canPlayMimeType should have been called");
+    assert.ok(createSpy.calledOnce, "Local connection should have been used");
+
+    done();
+  });
+});
+
 test("for desktop devices, try each url on each connection", function(assert) {
   let done = assert.async();
   let urls              = ["first-test-url.mp3", "second-test-url.mp3", "third-test-url.mp3"];

--- a/tests/unit/services/hifi-test.js
+++ b/tests/unit/services/hifi-test.js
@@ -404,7 +404,7 @@ test("consumer can specify a mime type for a url", function(assert) {
 
   promise.then(() => {
     assert.ok(mimeTypeSpy.calledOnce, "local canPlayMimeType should have been called");
-    assert.ok(createSpy.calledOnce, "Local connection should have been used");
+    assert.ok(createSpy.calledOnce, "A sound should have been created using the local dummy connection");
 
     done();
   });

--- a/tests/unit/utils/mime-types-test.js
+++ b/tests/unit/utils/mime-types-test.js
@@ -1,0 +1,21 @@
+import { getMimeType } from 'dummy/utils/mime-types';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | mime types');
+
+test('it works', function(assert) {
+  let mp3Url = "http://www.podtrac.com/pts/redirect.mp3/audio.wnyc.org/takeaway/takeaway022616-apple.mp3";
+  let mp3UrlWithParams = mp3Url + "?foobar";
+  let hlsUrl = "http://wnyc-wowza.streamguys.com/wnycfm/wnycfm.sdp/playlist.m3u8";
+  let unknownUrl = "http://fm939.wnyc.org/wnycfm";
+
+  let mp3Mime = getMimeType(mp3Url);
+  let mp3MimeWithParams = getMimeType(mp3UrlWithParams);
+  let m3u8Mime = getMimeType(hlsUrl);
+  let unknownMime = getMimeType(unknownUrl);
+  
+  assert.equal(mp3Mime, 'audio/mpeg');
+  assert.equal(mp3MimeWithParams, 'audio/mpeg');
+  assert.equal(m3u8Mime, 'application/vnd.apple.mpegurl');
+  assert.equal(unknownMime, false);
+});


### PR DESCRIPTION
for reasons beyond a user's control, a particular audio file may not
travel over the network with a file extension.

This is mostly a use case for streams, for instance at NY Public Radio
we serve some streams extension-less, since file extensions are not
really enforceable specs, where as content types or mime types are.

closes #8