### PR TITLE
Add option to always use single audio element

### DIFF
--- a/tests/unit/hifi-connections/base-test.js
+++ b/tests/unit/hifi-connections/base-test.js
@@ -3,7 +3,7 @@ import { moduleFor, test } from 'ember-qunit';
 let baseSound;
 
 moduleFor('ember-hifi@hifi-connection:base', 'Unit | Connection | base', {
-  needs:['util:promise-race'],
+  needs:['util:promise-race', 'service:hifi-logger'],
   beforeEach() {
     baseSound = this.subject({
       setup() {},


### PR DESCRIPTION
specifying `alwaysUseSharedAudioElement: true` in the emberHIfi config area of environment.js will force hifi to use a single shared audio element all the time, instead of just on mobile browsers as is done normally. 

This resolves an issue with cookied content providers that limit one connection per client (in this case, adswizz on wnyc) where without this option audio might stall out when switching between different audio resources.