### PR TITLE
Allow later versions of ember-getowner-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
-    "ember-getowner-polyfill": "1.0.1",
+    "ember-getowner-polyfill": "^1.0.1",
     "ember-poll": "^1.0.1"
   },
   "ember-addon": {


### PR DESCRIPTION
Without this I have to use multiple versions of ember-getowner-polyfill