### PR TITLE
Dummy and Dummier

### DIFF
--- a/addon/hifi-connections/dummy-connection.js
+++ b/addon/hifi-connections/dummy-connection.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import DebugLogging from 'ember-hifi/mixins/debug-logging';
 
 let ClassMethods = Ember.Mixin.create({
   setup() {},
@@ -7,9 +8,11 @@ let ClassMethods = Ember.Mixin.create({
   canPlayMimeType: () => true,
 });
 
-let DummyConnection = Ember.Object.extend(Ember.Evented, {
+let DummyConnection = Ember.Object.extend(Ember.Evented, DebugLogging, {
+  debugName: 'dummyConnection',
   position: 0,
   duration: 10000,
+  
   init() {
     this.on('audio-played',    () => {
       this.set('hasPlayed', true);

--- a/addon/hifi-connections/dummy-connection.js
+++ b/addon/hifi-connections/dummy-connection.js
@@ -10,6 +10,35 @@ let ClassMethods = Ember.Mixin.create({
 let DummyConnection = Ember.Object.extend(Ember.Evented, {
   position: 0,
   init() {
+    this.on('audio-played',    () => {
+      this.set('hasPlayed', true);
+      this.set('isLoading', false);
+      this.set('isPlaying', true);
+      this.set('error', null);
+      
+      // recover lost isLoading update
+      this.notifyPropertyChange('isLoading');
+    });
+
+    this.on('audio-paused',   () => {
+      this.set('isPlaying', false);
+    });
+    this.on('audio-ended',    () => { 
+      this.set('isPlaying', false);
+    });
+    
+    this.on('audio-load-error', (e) => {
+      if (this.get('hasPlayed')) {
+        this.set('isLoading', false);
+        this.set('isPlaying', false);
+      }
+      this.set('error', e);
+    });
+
+    this.on('audio-loaded', () => {
+      this.set('isLoading', false);
+    });
+    
     Ember.run.next(() => this.trigger('audio-ready'));
   },
   play({position} = {}) {

--- a/addon/hifi-connections/dummy-connection.js
+++ b/addon/hifi-connections/dummy-connection.js
@@ -9,6 +9,7 @@ let ClassMethods = Ember.Mixin.create({
 
 let DummyConnection = Ember.Object.extend(Ember.Evented, {
   position: 0,
+  duration: 10000,
   init() {
     this.on('audio-played',    () => {
       this.set('hasPlayed', true);
@@ -52,6 +53,12 @@ let DummyConnection = Ember.Object.extend(Ember.Evented, {
   },
   stop() {
     this.trigger('audio-paused');
+  },
+  fastForward(duration) {
+    this.set('position', this.get('position') + duration);
+  },
+  rewind(duration) {
+    this.set('position', this.get('position') - duration);
   },
   _setPosition() {},
   _currentPosition() {},

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -67,7 +67,6 @@ module.exports = {
     },
     {
       name: 'ember-canary',
-      allowedToFail: true, 
       bower: {
         dependencies: {
           'ember': 'components/ember#canary'

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
-    "ember-sinon": "0.5.1",
+    "ember-sinon": "0.6.0",
+    "ember-sinon-qunit": "1.4.1",
     "loader.js": "^4.0.10"
   },
   "keywords": [

--- a/tests/helpers/ember-hifi-test-helpers.js
+++ b/tests/helpers/ember-hifi-test-helpers.js
@@ -1,19 +1,18 @@
 import Ember from 'ember';
-import sinon from 'sinon';
 import DummyConnection from 'dummy/hifi-connections/local-dummy-connection';
 
 const {
   get
 } = Ember;
 
-function stubConnectionCreateWithSuccess(service, connectionName) {
+function stubConnectionCreateWithSuccess(service, connectionName, test) {
   let Connection =  get(service, `_connections.${connectionName}`);
-  sinon.stub(Connection, 'canPlay').returns(true);
+  test.stub(Connection, 'canPlay').returns(true);
 
-  let connectionSpy = sinon.stub(Connection, 'create', function() {
+  let connectionSpy = test.stub(Connection, 'create', function(options) {
     let sound =  DummyConnection.create(...arguments);
-    sinon.stub(sound, 'play', () => sound.trigger('audio-played'));
-    sinon.stub(sound, 'pause', () => sound.trigger('audio-paused'));
+    test.stub(sound, 'play', () => sound.trigger('audio-played'));
+    test.stub(sound, 'pause', () => sound.trigger('audio-paused'));
     
     Ember.run.next(() => sound.trigger('audio-ready'));
     return sound;
@@ -22,11 +21,11 @@ function stubConnectionCreateWithSuccess(service, connectionName) {
   return connectionSpy;
 }
 
-function stubConnectionCreateWithFailure(service, connectionName) {
+function stubConnectionCreateWithFailure(service, connectionName, test) {
   let Connection =  get(service, `_connections.${connectionName}`);
-  sinon.stub(Connection, 'canPlay').returns(true);
+  test.stub(Connection, 'canPlay').returns(true);
 
-  let connectionSpy = sinon.stub(Connection, 'create', function() {
+  let connectionSpy = test.stub(Connection, 'create', function(options) {
     console.log(`stubbed ${Connection} create called`);
     let sound =  DummyConnection.create(...arguments);
     Ember.run.next(() => sound.trigger('audio-load-error'));

--- a/tests/helpers/ember-hifi-test-helpers.js
+++ b/tests/helpers/ember-hifi-test-helpers.js
@@ -1,16 +1,22 @@
 import Ember from 'ember';
-import DummyConnection from 'dummy/hifi-connections/local-dummy-connection';
+import BaseSound from 'ember-hifi/hifi-connections/base';
 
 const {
   get
 } = Ember;
+
+const dummyOps = {
+  setup() {},
+  _audioDuration() {},
+  _setVolume() {}
+};
 
 function stubConnectionCreateWithSuccess(service, connectionName, test) {
   let Connection =  get(service, `_connections.${connectionName}`);
   test.stub(Connection, 'canPlay').returns(true);
 
   let connectionSpy = test.stub(Connection, 'create', function(options) {
-    let sound =  DummyConnection.create(...arguments);
+    let sound = BaseSound.create(Object.assign({}, dummyOps, options));
     test.stub(sound, 'play', () => sound.trigger('audio-played'));
     test.stub(sound, 'pause', () => sound.trigger('audio-paused'));
     
@@ -27,7 +33,7 @@ function stubConnectionCreateWithFailure(service, connectionName, test) {
 
   let connectionSpy = test.stub(Connection, 'create', function(options) {
     console.log(`stubbed ${Connection} create called`);
-    let sound =  DummyConnection.create(...arguments);
+    let sound = BaseSound.create(Object.assign({}, dummyOps, options));
     Ember.run.next(() => sound.trigger('audio-load-error'));
     return sound;
   });
@@ -37,5 +43,6 @@ function stubConnectionCreateWithFailure(service, connectionName, test) {
 
 export {
   stubConnectionCreateWithSuccess,
-  stubConnectionCreateWithFailure
+  stubConnectionCreateWithFailure,
+  dummyOps
 };

--- a/tests/unit/services/hifi-test.js
+++ b/tests/unit/services/hifi-test.js
@@ -1,11 +1,12 @@
 import Ember from 'ember';
-import { moduleFor, test } from 'ember-qunit';
+import { moduleFor } from 'ember-qunit';
+import test from 'ember-sinon-qunit/test-support/test';
 import sinon from 'sinon';
 const { get, set } = Ember;
 import DummyConnection from 'dummy/hifi-connections/local-dummy-connection';
 import { stubConnectionCreateWithSuccess, stubConnectionCreateWithFailure } from '../../helpers/ember-hifi-test-helpers';
 
-let sandbox, hifiConnections, options;
+let hifiConnections, options;
 
 moduleFor('service:hifi', 'Unit | Service | hifi', {
   // Specify the other units that are required for this test.
@@ -18,8 +19,6 @@ moduleFor('service:hifi', 'Unit | Service | hifi', {
     'hifi-connection:local-dummy-connection'
   ],
   beforeEach() {
-    sandbox = sinon.sandbox.create();
-
     // All hifi connections. Use chooseActiveConnections to set order and activation
     hifiConnections = [
       {
@@ -63,10 +62,6 @@ moduleFor('service:hifi', 'Unit | Service | hifi', {
 
     this.register('service:hifi-cache', soundCacheStub);
     this.inject.service('hifi-cache', { as: 'soundCache' });
-  },
-
-  afterEach() {
-    sandbox.restore();
   }
 });
 
@@ -119,21 +114,21 @@ test('#load tries the first connection that says it can handle the url', functio
   let NativeAudio       =  get(service, `_connections.NativeAudio`);
   let LocalDummyConnection =  get(service, `_connections.LocalDummyConnection`);
 
-  let howlerSpy         = sinon.stub(Howler, 'canPlay').returns(false);
-  let nativeSpy         = sinon.stub(NativeAudio, 'canPlay').returns(true);
-  let localSpy          = sinon.stub(LocalDummyConnection, 'canPlay').returns(false);
+  let howlerSpy         = this.stub(Howler, 'canPlay').returns(false);
+  let nativeSpy         = this.stub(NativeAudio, 'canPlay').returns(true);
+  let localSpy          = this.stub(LocalDummyConnection, 'canPlay').returns(false);
 
   let sound             = DummyConnection.create();
 
-  let nativeCreateSpy   = sinon.stub(NativeAudio, 'create', function() {
+  let nativeCreateSpy   = this.stub(NativeAudio, 'create', function() {
     let sound =  DummyConnection.create(...arguments);
     Ember.run.next(() => sound.trigger('audio-ready'));
 
     return sound;
   });
 
-  let howlerCreateSpy   = sinon.stub(Howler, 'create').returns(sinon.createStubInstance(Howler));
-  let localCreateSpy    = sinon.stub(LocalDummyConnection, 'create').returns(sinon.createStubInstance(LocalDummyConnection));
+  let howlerCreateSpy   = this.stub(Howler, 'create').returns(sinon.createStubInstance(Howler));
+  let localCreateSpy    = this.stub(LocalDummyConnection, 'create').returns(sinon.createStubInstance(LocalDummyConnection));
 
   let promise = service.load(testUrl);
 
@@ -166,9 +161,9 @@ test('#load stops trying urls after a sound loads and reports accurately', funct
   let expectedFailures;
 
   let LocalDummyConnection =  get(service, `_connections.LocalDummyConnection`);
-  sinon.stub(LocalDummyConnection, 'canPlay').returns(true);
+  this.stub(LocalDummyConnection, 'canPlay').returns(true);
 
-  let localCreateSpy = sinon.stub(LocalDummyConnection, 'create', function() {
+  let localCreateSpy = this.stub(LocalDummyConnection, 'create', function(options) {
     let sound = DummyConnection.create(...arguments);
 
     if (sound.get('url') === goodUrl) {
@@ -203,7 +198,7 @@ test('#load can take a promise that resolves urls', function(assert) {
   const service      = this.subject({ options: chooseActiveConnections('LocalDummyConnection') });
   let done           = assert.async();
 
-  let localCreateSpy = stubConnectionCreateWithSuccess(service, "LocalDummyConnection");
+  let localCreateSpy = stubConnectionCreateWithSuccess(service, "LocalDummyConnection", this);
   let goodUrl        = "http://example.org/good.mp3";
   let urlPromise     = new Ember.RSVP.Promise(resolve => {
     Ember.run.later(() => resolve([goodUrl]), 800);
@@ -223,7 +218,7 @@ test('When a sound gets created it gets registered with OneAtATime', function(as
   let done = assert.async();
   assert.expect(1);
   const service = this.subject({ options: chooseActiveConnections('LocalDummyConnection') });
-  stubConnectionCreateWithSuccess(service, "LocalDummyConnection");
+  stubConnectionCreateWithSuccess(service, "LocalDummyConnection", this);
 
   let url = "/test/test.mp3";
 
@@ -236,7 +231,7 @@ test('When a sound gets created it gets registered with OneAtATime', function(as
 test('When a sound plays it gets set as the currentSound', function(assert) {
   assert.expect(3);
   const service = this.subject({ options: chooseActiveConnections('NativeAudio') });
-  stubConnectionCreateWithSuccess(service, "NativeAudio");
+  stubConnectionCreateWithSuccess(service, "NativeAudio", this);
 
   let sound1, sound2;
   return service.load("/test/yes.mp3").then(({sound}) => {
@@ -258,7 +253,7 @@ test('When a sound plays it gets set as the currentSound', function(assert) {
 test('Calling setCurrentSound multiple times will not register duplicate events on the sound', function(assert) {
   assert.expect(2);
   const service = this.subject({ options: chooseActiveConnections('NativeAudio') });
-  stubConnectionCreateWithSuccess(service, "NativeAudio");
+  stubConnectionCreateWithSuccess(service, "NativeAudio", this);
 
   return service.load("/test/yes.mp3").then(({sound}) => {
     let callCount = 0;
@@ -286,13 +281,13 @@ test('The second time a url is requested it will be pulled from the cache', func
   let done = assert.async();
   assert.expect(5);
   const service = this.subject({ options: chooseActiveConnections('LocalDummyConnection') });
-  let localconnectionSpy = stubConnectionCreateWithSuccess(service, "LocalDummyConnection");
+  let localconnectionSpy = stubConnectionCreateWithSuccess(service, "LocalDummyConnection", this);
 
   let url = "/test/test.mp3";
 
   let soundCache = service.get('soundCache');
-  let findSpy = sinon.stub(soundCache, 'find');
-  let cacheSpy = sinon.stub(soundCache, 'cache');
+  let findSpy = this.stub(soundCache, 'find');
+  let cacheSpy = this.stub(soundCache, 'cache');
 
   findSpy.onFirstCall().returns(false);
 
@@ -315,13 +310,13 @@ test('The second time a url (with a mime type specified) is requested it will be
   let done = assert.async();
   assert.expect(5);
   const service = this.subject({ options: chooseActiveConnections('LocalDummyConnection') });
-  let localconnectionSpy = stubConnectionCreateWithSuccess(service, "LocalDummyConnection");
+  let localconnectionSpy = stubConnectionCreateWithSuccess(service, "LocalDummyConnection", this);
 
   let url = {url: "/test/test.mp3", mimeType: "audio/mp3"};
 
   let soundCache = service.get('soundCache');
-  let findSpy = sinon.stub(soundCache, 'find');
-  let cacheSpy = sinon.stub(soundCache, 'cache');
+  let findSpy = this.stub(soundCache, 'find');
+  let cacheSpy = this.stub(soundCache, 'cache');
 
   findSpy.onFirstCall().returns(false);
 
@@ -351,8 +346,8 @@ test('position gets polled regularly on the currentSound but not on the others',
   let sound1 = DummyConnection.create({});
   let sound2 = DummyConnection.create({});
 
-  let spy1 = sinon.spy(sound1, '_currentPosition');
-  let spy2 = sinon.spy(sound2, '_currentPosition');
+  let spy1 = this.spy(sound1, '_currentPosition');
+  let spy2 = this.spy(sound2, '_currentPosition');
 
   assert.equal(spy1.callCount, 0, "sound 1 should not have been polled yet");
   assert.equal(spy2.callCount, 0, "sound 1 should not have been polled yet");
@@ -379,8 +374,8 @@ test('volume changes are set on the current sound', function(assert) {
   let sound1 = DummyConnection.create({});
   let sound2 = DummyConnection.create({});
 
-  let spy1 = sinon.spy(sound1, '_setVolume');
-  let spy2 = sinon.spy(sound2, '_setVolume');
+  let spy1 = this.spy(sound1, '_setVolume');
+  let spy2 = this.spy(sound2, '_setVolume');
 
   let defaultVolume = service.get('defaultVolume');
 
@@ -423,7 +418,7 @@ test('toggleMute returns sound to previous level', function(assert) {
 test("consumer can specify the connection to use with a particular url", function(assert) {
   let done = assert.async();
   let service = this.subject({ options: chooseActiveConnections('LocalDummyConnection', 'Howler', 'NativeAudio') });
-  let nativeAudioSpy = stubConnectionCreateWithSuccess(service, "NativeAudio");
+  let nativeAudioSpy = stubConnectionCreateWithSuccess(service, "NativeAudio", this);
 
   service.load("/here/is/a/test/url/test.mp3", {useConnections: ['NativeAudio']}).then(() => {
     assert.equal(nativeAudioSpy.callCount, 1, "Native connection should have been called");
@@ -435,9 +430,9 @@ test("consumer can specify the order of connections to be used with a some urls"
   let done = assert.async();
 
   let service           = this.subject({ options: chooseActiveConnections('LocalDummyConnection', 'Howler', 'NativeAudio') });
-  let nativeAudioSpy    = stubConnectionCreateWithFailure(service, "NativeAudio");
-  let localAudioSpy     = stubConnectionCreateWithSuccess(service, "LocalDummyConnection");
-  let howlerAudioSpy    = stubConnectionCreateWithSuccess(service, "Howler");
+  let nativeAudioSpy    = stubConnectionCreateWithFailure(service, "NativeAudio", this);
+  let localAudioSpy     = stubConnectionCreateWithSuccess(service, "LocalDummyConnection", this);
+  let howlerAudioSpy    = stubConnectionCreateWithSuccess(service, "Howler", this);
 
   return service.load("/first/test.mp3", {useConnections: ['NativeAudio', 'LocalDummyConnection']}).then(() => {
     assert.equal(nativeAudioSpy.callCount, 1, "Native connection should have been called");
@@ -461,8 +456,8 @@ test("consumer can specify a mime type for a url", function(assert) {
 
   let LocalDummyConnection = get(service, `_connections.LocalDummyConnection`);
 
-  let mimeTypeSpy = sinon.stub(LocalDummyConnection, 'canPlayMimeType').returns(true);
-  let createSpy   = sinon.stub(LocalDummyConnection, 'create', function() {
+  let mimeTypeSpy = this.stub(LocalDummyConnection, 'canPlayMimeType').returns(true);
+  let createSpy   = this.stub(LocalDummyConnection, 'create', function() {
     let sound =  DummyConnection.create(...arguments);
     Ember.run.next(() => sound.trigger('audio-ready'));
     return sound;
@@ -486,7 +481,7 @@ test("if a mime type cannot be determined, try to play it anyway", function(asse
 
   let LocalDummyConnection = get(service, `_connections.LocalDummyConnection`);
 
-  let createSpy   = sinon.stub(LocalDummyConnection, 'create', function() {
+  let createSpy   = this.stub(LocalDummyConnection, 'create', function() {
     let sound =  DummyConnection.create(...arguments);
     Ember.run.next(() => sound.trigger('audio-ready'));
     return sound;
@@ -509,12 +504,12 @@ test("for desktop devices, try each url on each connection", function(assert) {
   let service           = this.subject({ options: chooseActiveConnections(...connections) });
   service.set('isMobileDevice', false);
 
-  stubConnectionCreateWithSuccess(service, "NativeAudio");
-  stubConnectionCreateWithSuccess(service, "LocalDummyConnection");
-  stubConnectionCreateWithSuccess(service, "Howler");
+  stubConnectionCreateWithSuccess(service, "NativeAudio", this);
+  stubConnectionCreateWithSuccess(service, "LocalDummyConnection", this);
+  stubConnectionCreateWithSuccess(service, "Howler", this);
 
-  let strategySpy       = sinon.spy(service, '_prepareStandardStrategies');
-  let findAudioSpy      = sinon.spy(service, '_findFirstPlayableSound');
+  let strategySpy       = this.spy(service, '_prepareStandardStrategies');
+  let findAudioSpy      = this.spy(service, '_findFirstPlayableSound');
 
   return service.load(urls).then(() => {
     assert.equal(strategySpy.callCount, 1, "Standard strategy should have been used");
@@ -548,12 +543,12 @@ test("for mobile devices, try all the urls on the native audio connection first,
   let connections       = ['LocalDummyConnection', 'Howler', 'NativeAudio'];
   let service           = this.subject({ options: chooseActiveConnections(...connections) });
 
-  stubConnectionCreateWithSuccess(service, "NativeAudio");
-  stubConnectionCreateWithSuccess(service, "LocalDummyConnection");
-  stubConnectionCreateWithSuccess(service, "Howler");
+  stubConnectionCreateWithSuccess(service, "NativeAudio", this);
+  stubConnectionCreateWithSuccess(service, "LocalDummyConnection", this);
+  stubConnectionCreateWithSuccess(service, "Howler", this);
 
-  let strategySpy       = sinon.spy(service, '_prepareMobileStrategies');
-  let findAudioSpy      = sinon.spy(service, '_findFirstPlayableSound');
+  let strategySpy       = this.spy(service, '_prepareMobileStrategies');
+  let findAudioSpy      = this.spy(service, '_findFirstPlayableSound');
 
   service.set('isMobileDevice', true);
 
@@ -592,13 +587,13 @@ test("for mobile devices, audio element should still be passed if a custom strat
   let connections = ['LocalDummyConnection', 'Howler', 'NativeAudio'];
   let service     = this.subject({ options: chooseActiveConnections(...connections) });
 
-  stubConnectionCreateWithSuccess(service, "NativeAudio");
-  stubConnectionCreateWithSuccess(service, "LocalDummyConnection");
-  stubConnectionCreateWithSuccess(service, "Howler");
+  stubConnectionCreateWithSuccess(service, "NativeAudio", this);
+  stubConnectionCreateWithSuccess(service, "LocalDummyConnection", this);
+  stubConnectionCreateWithSuccess(service, "Howler", this);
 
-  let strategySpy       = sinon.spy(service, '_prepareMobileStrategies');
-  let customStrategySpy = sinon.spy(service, '_prepareStrategies');
-  let findAudioSpy      = sinon.spy(service, '_findFirstPlayableSound');
+  let strategySpy       = this.spy(service, '_prepareMobileStrategies');
+  let customStrategySpy = this.spy(service, '_prepareStrategies');
+  let findAudioSpy      = this.spy(service, '_findFirstPlayableSound');
 
   service.set('isMobileDevice', true);
 
@@ -641,11 +636,11 @@ test("shared audio element should be passed if alwaysUseSingleAudioElement confi
   let connections = ['LocalDummyConnection', 'Howler', 'NativeAudio'];
   let service     = this.subject({ options: chooseActiveConnections(...connections) });
 
-  stubConnectionCreateWithSuccess(service, "NativeAudio");
-  stubConnectionCreateWithSuccess(service, "LocalDummyConnection");
-  stubConnectionCreateWithSuccess(service, "Howler");
+  stubConnectionCreateWithSuccess(service, "NativeAudio", this);
+  stubConnectionCreateWithSuccess(service, "LocalDummyConnection", this);
+  stubConnectionCreateWithSuccess(service, "Howler", this);
 
-  let findAudioSpy      = sinon.spy(service, '_findFirstPlayableSound');
+  let findAudioSpy      = this.spy(service, '_findFirstPlayableSound');
 
   service.set('isMobileDevice', false);
   service.set('alwaysUseSingleAudioElement', true);


### PR DESCRIPTION
This PR does a few things
* Make `DummyConnection` more "alive" with event wiring, which is useful in upstream libs, i.e. `wnyc-web-client` or `nypr-player`
* Replace `sinon` for `ember-sinon-qunit` in the hifi service unit test
* Make `ember-canary` pass (fixed those "already wrapped canPlay" errors)