### PR TITLE
Hifi's `play` shouldn't resolve until the sound is set

### DIFF
--- a/addon/services/hifi.js
+++ b/addon/services/hifi.js
@@ -212,14 +212,14 @@ export default Service.extend(Ember.Evented, DebugLogging, {
     this.set('isLoading', true);
 
     let load = this.load(urlsOrPromise, options);
-    load.then(({sound}) => {
-      this.debug("ember-hifi", "Finished load, trying to play sound");
-      this._attemptToPlaySound(sound, options);
-    });
 
     // We want to keep this chainable elsewhere
     return new RSVP.Promise((resolve, reject) => {
-      load.then(({sound, failures}) => sound.one('audio-played', () => resolve({sound, failures})));
+      load.then(({sound, failures}) => {
+        this.debug("ember-hifi", "Finished load, trying to play sound");
+        sound.one('audio-played', () => resolve({sound, failures}));
+        this._attemptToPlaySound(sound, options);
+      });
       load.catch(reject);
     });
   },

--- a/addon/services/hifi.js
+++ b/addon/services/hifi.js
@@ -218,7 +218,10 @@ export default Service.extend(Ember.Evented, DebugLogging, {
     });
 
     // We want to keep this chainable elsewhere
-    return load;
+    return new RSVP.Promise((resolve, reject) => {
+      load.then(({sound, failures}) => sound.one('audio-played', () => resolve({sound, failures})));
+      load.catch(reject);
+    });
   },
 
   /**

--- a/tests/unit/services/hifi-test.js
+++ b/tests/unit/services/hifi-test.js
@@ -719,3 +719,15 @@ test("sound can play on native audio using shared element one after the other", 
     silence1.set('position', 10 * 60 * 1000);
   });
 });
+
+test("service has access to the current sound inside the play callback", function(assert) {
+  let done        = assert.async();
+  let connections = ['NativeAudio'];
+  let service     = this.subject({ options: chooseActiveConnections(...connections) });
+  let s1url       = "/assets/silence.mp3";
+  
+  return service.play(s1url).then(({sound}) => {
+    assert.equal(sound.get('position'), service.get('position'));
+    done();
+  });
+});


### PR DESCRIPTION
The hifi service's `currentSound` wasn't available if you chained off `.play`, e.g.:
```javascript
play() {
  this.get('hifi').play('/audio.mp3').then(sound => {
    this.get('hifi.position'); // undefined
    sound.get('position'); // 0
  });
}
```
but we ideally want people to access these props through hifi instead of the `sound`. Sound access is a convenience.