### PR TITLE
Event bug fixes discovered when implementing analytics from hifi events

### DIFF
--- a/addon/hifi-connections/native-audio.js
+++ b/addon/hifi-connections/native-audio.js
@@ -114,6 +114,11 @@ let Sound = BaseSound.extend({
       return;
     }
 
+    if (this.get('isPlaying')) {
+      // send a pause event so anyone subscribed to hifi's relayed events gets the message
+      this._onAudioPaused(this);
+    }
+
     this.get('sharedAudioAccess').releaseControl(this);
 
     // save current state of audio element to the internal element that won't be played

--- a/addon/services/hifi.js
+++ b/addon/services/hifi.js
@@ -230,6 +230,8 @@ export default Service.extend(Ember.Evented, DebugLogging, {
       load.then(({sound, failures}) => {
         this.debug("ember-hifi", "Finished load, trying to play sound");
         sound.one('audio-played', () => resolve({sound, failures}));
+
+        this._registerEvents(sound);
         this._attemptToPlaySound(sound, options);
       });
       load.catch(reject);
@@ -385,6 +387,8 @@ export default Service.extend(Ember.Evented, DebugLogging, {
    */
 
   _registerEvents(sound) {
+    this._unregisterEvents(sound);
+
     let service = this;
     sound.on('audio-played',           service,   service._relayPlayedEvent);
     sound.on('audio-paused',           service,   service._relayPausedEvent);

--- a/addon/services/hifi.js
+++ b/addon/services/hifi.js
@@ -200,7 +200,7 @@ export default Service.extend(Ember.Evented, DebugLogging, {
       let currentSound  = sound;
 
       if (previousSound !== currentSound) {
-        this.trigger('current-sound-changed', {previousSound, currentSound});
+        this.trigger('current-sound-changed', currentSound, previousSound);
         this.setCurrentSound(sound);
       }
     }));

--- a/tests/unit/hifi-connections/native-audio-test.js
+++ b/tests/unit/hifi-connections/native-audio-test.js
@@ -186,7 +186,6 @@ test('switching sounds with internal elements keep current state', function(asse
   assert.equal(sound2._currentPosition(), 10000, "sound 2 should have kept its position");
 });
 
-
 test('on setup the sound has control of the shared audio element', function(assert) {
   let url1 = '/assets/silence.mp3';
   let sharedAudioAccess = SharedAudioAccess.unlock();
@@ -232,4 +231,25 @@ test("when using a shared audio element we set preload=none on the shadow elemen
   sound.stop();
 
   assert.equal(sound.get('_audioElement').preload,  'none', "audio preload attribute is none");
+});
+
+test('switching sounds with a shared audio element sends pause event on first sound', function(assert) {
+  // let done = assert.async();
+  let url1 = '/assets/silence.mp3';
+  let url2 = '/assets/silence2.mp3';
+  let sharedAudioAccess = SharedAudioAccess.unlock();
+
+  let sound1 = NativeAudio.create({url: url1, timeout: false, sharedAudioAccess});
+  let sound2 = NativeAudio.create({url: url2, timeout: false, sharedAudioAccess});
+
+  let pauseStub = sinon.stub(sound1, '_onAudioPaused');
+
+  sinon.stub(sound1, 'debug');
+  sinon.stub(sound2, 'debug');
+
+  sound1.play(); // sound 1 has control
+  sound1.set('isPlaying', true);
+  sound2.play(); // sound 2 has control
+
+  assert.equal(pauseStub.callCount, 1, "audio 1 pause event should have been fired");
 });

--- a/tests/unit/services/hifi-test.js
+++ b/tests/unit/services/hifi-test.js
@@ -738,7 +738,6 @@ test("sound events get relayed at the service level", function(assert) {
   let s1url       = "/assets/silence.mp3";
   let s2url       = "/assets/silence2.mp3";
 
-  let sound1, sound2;
   let sound1PlayEventTriggered;
   let sound2PlayEventTriggered;
   let sound1PauseEventTriggered;
@@ -754,11 +753,9 @@ test("sound events get relayed at the service level", function(assert) {
     sound2PauseEventTriggered = (sound.get('url') === s2url);
   });
 
-  service.play(s1url).then(({sound}) => {
-    sound1 = sound;
+  service.play(s1url).then(() => {
     assert.equal(sound1PlayEventTriggered, true, "sound 1 play event should have been triggered");
     service.play(s2url).then(({sound}) => {
-      sound2 = sound;
       assert.equal(sound1PauseEventTriggered, true, "sound 1 pause event should have been triggered");
       assert.equal(sound2PlayEventTriggered, true, "sound 2 play event should have been triggered");
       sound.pause();
@@ -777,13 +774,13 @@ test("service triggers `current-sound-changed` event when sounds change", functi
 
   assert.expect(4);
 
-  service.one('current-sound-changed', ({previousSound, currentSound}) => {
+  service.one('current-sound-changed', (currentSound, previousSound) => {
     assert.equal(previousSound, undefined, "there should not a previous sound");
     assert.equal(currentSound.get('url'), s1url, "current sound should be the first sound");
   });
 
   return service.play(s1url).then(() => {
-    service.one('current-sound-changed', ({previousSound, currentSound}) => {
+    service.one('current-sound-changed', (currentSound, previousSound) => {
       assert.equal(previousSound.get('url'), "/assets/silence.mp3", "previous sound should be this sound");
       assert.equal(currentSound.get('url'), "/assets/silence2.mp3");
     });


### PR DESCRIPTION
Make sure events of not-yet-current-sound are relayed through hifi, and make sure pause event gets fired when using a shared element and transferring control