### PR TITLE
New test helpers and a new events

### DIFF
--- a/addon/hifi-connections/base.js
+++ b/addon/hifi-connections/base.js
@@ -91,6 +91,8 @@ let Sound = Ember.Object.extend(Ember.Evented, DebugLogging, {
       return this._currentPosition();
     },
     set(k, v) {
+      this.trigger('audio-position-will-change', this, {currentPosition: this._currentPosition(), newPosition: v});
+
       return this._setPosition(v);
     }
   }),
@@ -183,18 +185,19 @@ let Sound = Ember.Object.extend(Ember.Evented, DebugLogging, {
     let currentPosition = this._currentPosition();
     let newPosition     = (currentPosition + duration);
 
+    this.trigger('audio-will-fast-forward', this, {currentPosition, newPosition});
     this._setPosition(newPosition > audioLength ? audioLength : newPosition);
   },
 
   rewind(duration) {
     let currentPosition = this._currentPosition();
-    let newPosition     = (currentPosition - duration);
+    let newPosition     = Math.max((currentPosition - duration), 0);
 
-    this._setPosition(newPosition < 0 ? 0 : newPosition);
+    this.trigger('audio-will-rewind', this, {currentPosition, newPosition});
+    this._setPosition(newPosition);
   },
 
   /* To be defined on the subclass */
-
   setup() {
     assert("[ember-hifi] #setup interface not implemented", false);
   },

--- a/addon/hifi-connections/base.js
+++ b/addon/hifi-connections/base.js
@@ -116,7 +116,7 @@ let Sound = Ember.Object.extend(Ember.Evented, DebugLogging, {
       this.set('error', null);
 
       if (audioPlayed) { audioLoading(this); }
-      
+
       // recover lost isLoading update
       this.notifyPropertyChange('isLoading');
     });
@@ -192,7 +192,6 @@ let Sound = Ember.Object.extend(Ember.Evented, DebugLogging, {
   rewind(duration) {
     let currentPosition = this._currentPosition();
     let newPosition     = Math.max((currentPosition - duration), 0);
-
     this.trigger('audio-will-rewind', this, {currentPosition, newPosition});
     this._setPosition(newPosition);
   },

--- a/addon/hifi-connections/base.js
+++ b/addon/hifi-connections/base.js
@@ -183,10 +183,10 @@ let Sound = Ember.Object.extend(Ember.Evented, DebugLogging, {
   fastForward(duration) {
     let audioLength     = this._audioDuration();
     let currentPosition = this._currentPosition();
-    let newPosition     = (currentPosition + duration);
+    let newPosition     = Math.min((currentPosition + duration), audioLength);
 
     this.trigger('audio-will-fast-forward', this, {currentPosition, newPosition});
-    this._setPosition(newPosition > audioLength ? audioLength : newPosition);
+    this._setPosition(newPosition);
   },
 
   rewind(duration) {

--- a/addon/hifi-connections/base.js
+++ b/addon/hifi-connections/base.js
@@ -123,7 +123,7 @@ let Sound = Ember.Object.extend(Ember.Evented, DebugLogging, {
       this.set('isPlaying', false);
       if (audioPaused) { audioPaused(this); }
     });
-    this.on('audio-ended',    () => { 
+    this.on('audio-ended',    () => {
       this.set('isPlaying', false);
       if (audioEnded) { audioEnded(this); }
     });

--- a/addon/hifi-connections/dummy-connection.js
+++ b/addon/hifi-connections/dummy-connection.js
@@ -72,7 +72,6 @@ let DummyConnection = BaseSound.extend({
   },
   _setPosition(duration) {
     this.set('_dummy_position', duration);
-
     return duration;
   },
   _currentPosition() {

--- a/addon/hifi-connections/dummy-connection.js
+++ b/addon/hifi-connections/dummy-connection.js
@@ -23,14 +23,14 @@ let DummyConnection = BaseSound.extend({
   },
 
   stopTicking: function() {
-    Ember.run.cancel(this.tick);
+    window.clearTimeout(this.tick);
   },
 
   startTicking: function() {
-    this.tick = Ember.run.later(() => {
-      this._setPosition((this._currentPosition() || 0) + 1000);
+    this.tick = window.setTimeout(Ember.run.bind(() => {
+      this._setPosition((this._currentPosition() || 0) + 100);
       this.startTicking();
-    }, 1000);
+    }), 100)
   },
 
   getInfoFromUrl: function() {

--- a/addon/hifi-connections/dummy-connection.js
+++ b/addon/hifi-connections/dummy-connection.js
@@ -11,7 +11,7 @@ let ClassMethods = Ember.Mixin.create({
 
 let DummyConnection = BaseSound.extend({
   debugName: 'dummyConnection',
-  _position: 0,
+  _dummy_position: 0,
   setup() {
     let {result} = this.getInfoFromUrl();
     if (result === 'bad') {
@@ -23,14 +23,14 @@ let DummyConnection = BaseSound.extend({
   },
 
   stopTicking: function() {
-    Ember.run.cancel(this.tick());
+    Ember.run.cancel(this.tick);
   },
 
   startTicking: function() {
     this.tick = Ember.run.later(() => {
-      this._setPosition((this._currentPosition() || 0) + 100);
+      this._setPosition((this._currentPosition() || 0) + 1000);
       this.startTicking();
-    }, 100);
+    }, 1000);
   },
 
   getInfoFromUrl: function() {
@@ -39,15 +39,15 @@ let DummyConnection = BaseSound.extend({
     return {result, length, name};
   },
 
-  handlePositioningEvents: Ember.observer('_position', function(){
-    if (this.get('_position') >= this._audioDuration()) {
+  handlePositioningEvents: Ember.observer('_dummy_position', function(){
+    if (this.get('_dummy_position') >= this._audioDuration()) {
       this.trigger('audio-ended', this);
     }
   }),
 
   play({position} = {}) {
     if (typeof position !== 'undefined') {
-      this.set('_position', position);
+      this.set('_dummy_position', position);
     }
     this.trigger('audio-played', this);
     this.startTicking();
@@ -61,16 +61,18 @@ let DummyConnection = BaseSound.extend({
     this.stopTicking();
   },
   fastForward(duration) {
-    this.set('_position', this.get('position') + duration);
+    this.set('_dummy_position', this._currentPosition() + duration);
   },
   rewind(duration) {
-    this.set('_position', this.get('position') - duration);
+    this.set('_dummy_position', this._currentPosition() - duration);
   },
   _setPosition(duration) {
-    this.set('_position', duration);
+    this.set('_dummy_position', duration);
+
+    return duration;
   },
   _currentPosition() {
-    return this.get('_position');
+    return this.get('_dummy_position');
   },
   _setVolume(v) {
     this.set('volume', v);

--- a/addon/hifi-connections/dummy-connection.js
+++ b/addon/hifi-connections/dummy-connection.js
@@ -14,7 +14,7 @@ let ClassMethods = Ember.Mixin.create({
 
 let DummyConnection = BaseSound.extend({
   debugName: 'dummyConnection',
-  _dummy_position: 0,
+  _position: 0,
   _tickInterval: 50,
   setup() {
     let {result} = this.getInfoFromUrl();
@@ -43,15 +43,9 @@ let DummyConnection = BaseSound.extend({
     return {result, length, name};
   },
 
-  handlePositioningEvents: Ember.observer('_dummy_position', function(){
-    if (this.get('_dummy_position') >= this._audioDuration()) {
-      this.trigger('audio-ended', this);
-    }
-  }),
-
   play({position} = {}) {
     if (typeof position !== 'undefined') {
-      this.set('_dummy_position', position);
+      this.set('_position', position);
     }
     this.trigger('audio-played', this);
     this.startTicking();
@@ -67,16 +61,16 @@ let DummyConnection = BaseSound.extend({
   _setPosition(duration) {
     duration = Math.max(0, duration);
     duration = Math.min(this._audioDuration(), duration);
-    this.set('_dummy_position', duration);
+    this.set('_position', duration);
 
     if (duration >= this._audioDuration()) {
-      this.trigger('audio-ended', this);
+      Ember.run.next(() => this.trigger('audio-ended', this));
     }
 
     return duration;
   },
   _currentPosition() {
-    return this.get('_dummy_position');
+    return this.get('_position');
   },
   _setVolume(v) {
     this.set('volume', v);

--- a/addon/hifi-connections/dummy-connection.js
+++ b/addon/hifi-connections/dummy-connection.js
@@ -12,6 +12,7 @@ let ClassMethods = Ember.Mixin.create({
 let DummyConnection = BaseSound.extend({
   debugName: 'dummyConnection',
   _dummy_position: 0,
+  _tickInterval: 50,
   setup() {
     let {result} = this.getInfoFromUrl();
     if (result === 'bad') {
@@ -28,9 +29,9 @@ let DummyConnection = BaseSound.extend({
 
   startTicking: function() {
     this.tick = window.setTimeout(Ember.run.bind(() => {
-      this._setPosition((this._currentPosition() || 0) + 100);
+      this._setPosition((this._currentPosition() || 0) + this.get('_tickInterval'));
       this.startTicking();
-    }), 100)
+    }), this.get('_tickInterval'))
   },
 
   getInfoFromUrl: function() {

--- a/addon/hifi-connections/dummy-connection.js
+++ b/addon/hifi-connections/dummy-connection.js
@@ -6,6 +6,9 @@ let ClassMethods = Ember.Mixin.create({
   canPlay: () => true,
   canUseConnection: () => true,
   canPlayMimeType: () => true,
+  toString() {
+    return 'Dummy Connection';
+  }
 });
 
 

--- a/addon/hifi-connections/dummy-connection.js
+++ b/addon/hifi-connections/dummy-connection.js
@@ -64,14 +64,15 @@ let DummyConnection = BaseSound.extend({
     this.trigger('audio-paused', this);
     this.stopTicking();
   },
-  fastForward(duration) {
-    this.set('_dummy_position', this._currentPosition() + duration);
-  },
-  rewind(duration) {
-    this.set('_dummy_position', this._currentPosition() - duration);
-  },
   _setPosition(duration) {
+    duration = Math.max(0, duration);
+    duration = Math.min(this._audioDuration(), duration);
     this.set('_dummy_position', duration);
+
+    if (duration >= this._audioDuration()) {
+      this.trigger('audio-ended', this);
+    }
+
     return duration;
   },
   _currentPosition() {

--- a/addon/hifi-connections/dummy-connection.js
+++ b/addon/hifi-connections/dummy-connection.js
@@ -15,10 +15,10 @@ let DummyConnection = BaseSound.extend({
   setup() {
     let {result} = this.getInfoFromUrl();
     if (result === 'bad') {
-      Ember.run.next(() => this.trigger('audio-load-error'));
+      Ember.run.next(() => this.trigger('audio-load-error', this));
     }
     else {
-      Ember.run.next(() => this.trigger('audio-ready'));
+      Ember.run.next(() => this.trigger('audio-ready', this));
     }
   },
 
@@ -41,7 +41,7 @@ let DummyConnection = BaseSound.extend({
 
   handlePositioningEvents: Ember.observer('_position', function(){
     if (this.get('_position') >= this._audioDuration()) {
-      this.trigger('audio-ended');
+      this.trigger('audio-ended', this);
     }
   }),
 
@@ -53,11 +53,11 @@ let DummyConnection = BaseSound.extend({
     this.startTicking();
   },
   pause() {
-    this.trigger('audio-paused');
+    this.trigger('audio-paused', this);
     this.stopTicking();
   },
   stop() {
-    this.trigger('audio-paused');
+    this.trigger('audio-paused', this);
     this.stopTicking();
   },
   fastForward(duration) {

--- a/addon/hifi-connections/dummy-connection.js
+++ b/addon/hifi-connections/dummy-connection.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import BaseSound from './base';
-
 let ClassMethods = Ember.Mixin.create({
   setup() {},
   canPlay: () => true,
@@ -39,6 +38,20 @@ let DummyConnection = BaseSound.extend({
 
   getInfoFromUrl: function() {
     let [, result, length, name] = this.get('url').split('/');
+    /*eslint no-console: 0 */
+    if (!(result && length && name)) {
+      console.error('[dummy-connection] url format should be "/:result/:length/:name"');
+    }
+
+    if (!(length === 'stream' || parseInt(length) > 0)) {
+      console.error('[dummy-connection] url format should be "/:result/:length/:name"');
+      console.error(`[dummy-connection] length should be an integer or "stream". Was given ${this.get('url')}`);
+    }
+
+    if (!(result === 'good' || result === 'bad')) {
+      console.error('[dummy-connection] url format should be "/:result/:length/:name"');
+      console.error(`[dummy-connection] status should be 'good' or 'bad'. Was given ${this.get('url')}`);
+    }
 
     return {result, length, name};
   },

--- a/addon/hifi-connections/native-audio.js
+++ b/addon/hifi-connections/native-audio.js
@@ -184,7 +184,9 @@ let Sound = BaseSound.extend({
   },
 
   _onAudioPlayed() {
-    this.trigger('audio-played', this);
+    if (!this.get('isPlaying')) {
+      this.trigger('audio-played', this);
+    }
   },
 
   _onAudioEnded() {

--- a/addon/hifi-connections/native-audio.js
+++ b/addon/hifi-connections/native-audio.js
@@ -261,6 +261,15 @@ let Sound = BaseSound.extend({
 
   _audioDuration() {
     let audio = this.audioElement();
+
+    if (audio.duration > 172800000) {
+      // if audio is longer than 3 days in milliseconds,
+      // assume it's a stream, and set duration to infinity as it should be
+      // this is a bug in Opera and was reported on 5/25/2017
+
+      return Infinity;
+    }
+
     return audio.duration * 1000;
   },
 

--- a/addon/services/hifi.js
+++ b/addon/services/hifi.js
@@ -398,13 +398,17 @@ export default Service.extend(Ember.Evented, DebugLogging, {
     this._unregisterEvents(sound);
 
     let service = this;
-    sound.on('audio-played',           service,   service._relayPlayedEvent);
-    sound.on('audio-paused',           service,   service._relayPausedEvent);
-    sound.on('audio-ended',            service,   service._relayEndedEvent);
-    sound.on('audio-duration-changed', service,   service._relayDurationChangedEvent);
-    sound.on('audio-position-changed', service,   service._relayPositionChangedEvent);
-    sound.on('audio-loaded',           service,   service._relayLoadedEvent);
-    sound.on('audio-loading',          service,   service._relayLoadingEvent);
+    sound.on('audio-played',               service,   service._relayPlayedEvent);
+    sound.on('audio-paused',               service,   service._relayPausedEvent);
+    sound.on('audio-ended',                service,   service._relayEndedEvent);
+    sound.on('audio-duration-changed',     service,   service._relayDurationChangedEvent);
+    sound.on('audio-position-changed',     service,   service._relayPositionChangedEvent);
+    sound.on('audio-loaded',               service,   service._relayLoadedEvent);
+    sound.on('audio-loading',              service,   service._relayLoadingEvent);
+
+    sound.on('audio-position-will-change', service,   service._relayPositionWillChangeEvent);
+    sound.on('audio-will-rewind',          service,   service._relayWillRewindEvent);
+    sound.on('audio-will-fast-forward',    service,   service._relayWillFastForwardEvent);
   },
 
   /**
@@ -422,13 +426,17 @@ export default Service.extend(Ember.Evented, DebugLogging, {
       return;
     }
     let service = this;
-    sound.off('audio-played',           service,   service._relayPlayedEvent);
-    sound.off('audio-paused',           service,   service._relayPausedEvent);
-    sound.off('audio-ended',            service,   service._relayEndedEvent);
-    sound.off('audio-duration-changed', service,   service._relayDurationChangedEvent);
-    sound.off('audio-position-changed', service,   service._relayPositionChangedEvent);
-    sound.off('audio-loaded',           service,   service._relayLoadedEvent);
-    sound.off('audio-loading',          service,   service._relayLoadingEvent);
+    sound.off('audio-played',               service,   service._relayPlayedEvent);
+    sound.off('audio-paused',               service,   service._relayPausedEvent);
+    sound.off('audio-ended',                service,   service._relayEndedEvent);
+    sound.off('audio-duration-changed',     service,   service._relayDurationChangedEvent);
+    sound.off('audio-position-changed',     service,   service._relayPositionChangedEvent);
+    sound.off('audio-loaded',               service,   service._relayLoadedEvent);
+    sound.off('audio-loading',              service,   service._relayLoadingEvent);
+    
+    sound.off('audio-position-will-change', service,   service._relayPositionWillChangeEvent);
+    sound.off('audio-will-rewind',          service,   service._relayWillRewindEvent);
+    sound.off('audio-will-fast-forward',    service,   service._relayWillFastForwardEvent);
   },
 
   /**
@@ -440,8 +448,8 @@ export default Service.extend(Ember.Evented, DebugLogging, {
    * @return {Void}
    */
 
-  _relayEvent(eventName, sound) {
-    this.trigger(eventName, sound);
+  _relayEvent(eventName, sound, info = {}) {
+    this.trigger(eventName, sound, info);
   },
 
   /**
@@ -469,7 +477,15 @@ export default Service.extend(Ember.Evented, DebugLogging, {
   _relayLoadingEvent(sound) {
     this._relayEvent('audio-loading', sound);
   },
-
+  _relayPositionWillChangeEvent(sound,  info = {}) {
+    this._relayEvent('audio-position-will-change', sound, info);
+  },
+  _relayWillRewindEvent(sound,  info) {
+    this._relayEvent('audio-will-rewind', sound, info);
+  },
+  _relayWillFastForwardEvent(sound, info) {
+    this._relayEvent('audio-will-fast-forward', sound, info);
+  },
   /**
    * Activates the connections as specified in the config options
    *

--- a/addon/services/hifi.js
+++ b/addon/services/hifi.js
@@ -191,7 +191,6 @@ export default Service.extend(Ember.Evented, DebugLogging, {
     promise.then(({sound}) => sound.set('metadata', options.metadata));
     promise.then(({sound}) => this.get('soundCache').cache(sound));
 
-
     // On audio-played this pauses all the other sounds. One at a time!
     promise.then(({sound}) => this.get('oneAtATime').register(sound));
 
@@ -537,7 +536,7 @@ export default Service.extend(Ember.Evented, DebugLogging, {
       return Ember.A(Ember.makeArray(urls)).uniq().reject(i => Ember.isEmpty(i));
     };
 
-    if (urlsOrPromise.then) {
+    if (urlsOrPromise && urlsOrPromise.then) {
       this.debug('ember-hifi', "#load passed URL promise");
     }
 

--- a/addon/services/hifi.js
+++ b/addon/services/hifi.js
@@ -131,7 +131,10 @@ export default Service.extend(Ember.Evented, DebugLogging, {
     let sharedAudioAccess = this._createAndUnlockAudio();
     let assign = Ember.assign || Ember.merge;
 
-    options = assign({ debugName: `load-${Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 3)}`}, options);
+    options = assign({
+      debugName: `load-${Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 3)}`,
+      metadata: {},
+    }, options);
 
     let promise = new RSVP.Promise((resolve, reject) => {
       return this._resolveUrls(urlsOrPromise).then(urlsToTry => {
@@ -187,8 +190,9 @@ export default Service.extend(Ember.Evented, DebugLogging, {
       });
     });
 
+    this.trigger('new-load-request', {loadPromise:promise, urlsOrPromise, options});
 
-    promise.then(({sound}) => sound.set('metadata', (options.metadata || {})));
+    promise.then(({sound}) => sound.set('metadata', (options.metadata)));
     promise.then(({sound}) => this.get('soundCache').cache(sound));
 
     // On audio-played this pauses all the other sounds. One at a time!

--- a/addon/services/hifi.js
+++ b/addon/services/hifi.js
@@ -202,11 +202,11 @@ export default Service.extend(Ember.Evented, DebugLogging, {
       let previousSound = this.get('currentSound');
       let currentSound  = sound;
 
-      if (previousSound && get(previousSound, 'isPlaying')) {
-        this.trigger('current-sound-interrupted', previousSound);
-      }
-
       if (previousSound !== currentSound) {
+        if (previousSound && get(previousSound, 'isPlaying')) {
+          this.trigger('current-sound-interrupted', previousSound);
+        }
+
         this.trigger('current-sound-changed', currentSound, previousSound);
         this.setCurrentSound(sound);
       }

--- a/addon/services/hifi.js
+++ b/addon/services/hifi.js
@@ -198,6 +198,10 @@ export default Service.extend(Ember.Evented, DebugLogging, {
       let previousSound = this.get('currentSound');
       let currentSound  = sound;
 
+      if (previousSound && get(previousSound, 'isPlaying')) {
+        this.trigger('current-sound-interrupted', previousSound);
+      }
+
       if (previousSound !== currentSound) {
         this.trigger('current-sound-changed', currentSound, previousSound);
         this.setCurrentSound(sound);
@@ -217,6 +221,7 @@ export default Service.extend(Ember.Evented, DebugLogging, {
 
   play(urlsOrPromise, options) {
     if (this.get('isPlaying')) {
+      this.trigger('current-sound-interrupted', get(this, 'currentSound'));
       this.pause();
     }
     // update the UI immediately while `.load` figures out which sound is playable

--- a/addon/services/hifi.js
+++ b/addon/services/hifi.js
@@ -192,7 +192,7 @@ export default Service.extend(Ember.Evented, DebugLogging, {
 
     this.trigger('new-load-request', {loadPromise:promise, urlsOrPromise, options});
 
-    promise.then(({sound}) => sound.set('metadata', (options.metadata)));
+    promise.then(({sound}) => sound.set('metadata', options.metadata));
     promise.then(({sound}) => this.get('soundCache').cache(sound));
 
     // On audio-played this pauses all the other sounds. One at a time!
@@ -433,7 +433,7 @@ export default Service.extend(Ember.Evented, DebugLogging, {
     sound.off('audio-position-changed',     service,   service._relayPositionChangedEvent);
     sound.off('audio-loaded',               service,   service._relayLoadedEvent);
     sound.off('audio-loading',              service,   service._relayLoadingEvent);
-    
+
     sound.off('audio-position-will-change', service,   service._relayPositionWillChangeEvent);
     sound.off('audio-will-rewind',          service,   service._relayWillRewindEvent);
     sound.off('audio-will-fast-forward',    service,   service._relayWillFastForwardEvent);

--- a/addon/services/hifi.js
+++ b/addon/services/hifi.js
@@ -188,7 +188,7 @@ export default Service.extend(Ember.Evented, DebugLogging, {
     });
 
 
-    promise.then(({sound}) => sound.set('metadata', options.metadata));
+    promise.then(({sound}) => sound.set('metadata', (options.metadata || {})));
     promise.then(({sound}) => this.get('soundCache').cache(sound));
 
     // On audio-played this pauses all the other sounds. One at a time!

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -51,6 +51,7 @@ module.exports = {
     },
     {
       name: 'ember-beta',
+      allowedToFail: true,
       bower: {
         dependencies: {
           'ember': 'components/ember#beta'
@@ -67,6 +68,7 @@ module.exports = {
     },
     {
       name: 'ember-canary',
+      allowedToFail: true,
       bower: {
         dependencies: {
           'ember': 'components/ember#canary'

--- a/test-support/helpers/hifi-integration-helpers.js
+++ b/test-support/helpers/hifi-integration-helpers.js
@@ -1,0 +1,29 @@
+import Service from 'ember-hifi/services/hifi';
+import DummyConnection from 'ember-hifi/hifi-connections/dummy-connection';
+import hifiNeeds from './hifi-needs';
+
+const dummyHifi = Service.extend({
+  init: function() {
+    this.set('options', {
+      emberHifi: {
+        connections: [{
+          name: 'DummyConnection',
+          config: {
+            testOption: 'DummyConnection'
+          }
+        }]
+      }
+    });
+    this._super(...arguments);
+  },
+  _lookupConnection: function() {
+    return DummyConnection;
+  }
+});
+
+
+export {
+  DummyConnection,
+  dummyHifi,
+  hifiNeeds
+};

--- a/tests/dummy/app/services/audio.js
+++ b/tests/dummy/app/services/audio.js
@@ -1,0 +1,17 @@
+import Ember from 'ember';
+
+export default Ember.Service.extend({
+  hifi: Ember.inject.service(),
+
+  playGood() {
+    return this.get('hifi').play('/good/1252/ok.mp3');
+  },
+
+  playBad() {
+    return this.get('hifi').play('/bad/1252/ok.mp3');
+  },
+
+  playBlank() {
+    return this.get('hifi').play();
+  }
+});

--- a/tests/unit/hifi-connections/native-audio-test.js
+++ b/tests/unit/hifi-connections/native-audio-test.js
@@ -89,6 +89,22 @@ test("If it's a stream, we stop on pause", function(assert) {
   });
 });
 
+test("Don't fire audio-played events on position changes", function(assert) {
+  let sound = this.subject({url: '/assets/silence.mp3', timeout: false});
+  let done = assert.async();
+  assert.expect(1);
+
+  sound.on('audio-played', function() {
+    assert.ok('audio event fired');
+    sound._setPosition(1000);
+    sound._setPosition(2000);
+    sound._setPosition(3000);
+    done();
+  });
+  
+  sound.play();
+});
+
 test("stopping an audio stream still sends the pause event", function(assert) {
   let sharedAudioAccess = SharedAudioAccess.unlock();
 

--- a/tests/unit/services/hifi-integration-test.js
+++ b/tests/unit/services/hifi-integration-test.js
@@ -33,8 +33,7 @@ test('playing good url works', function(assert) {
 
 test('playing a bad url fails', function(assert) {
   let service = this.subject({});
-  let failures, success;
-
+  let failures, success = false;
   let play = service.playBad();
 
   play.then(() => (success = true));
@@ -43,7 +42,7 @@ test('playing a bad url fails', function(assert) {
     assert.ok(failures && failures.length > 0, "should have reported failures");
   });
 
-  assert.equal(!!success, false, "should not be successful")
+  assert.equal(success, false, "should not be successful")
 });
 
 test('playing a blank url fails', function(assert) {
@@ -109,6 +108,18 @@ test('it can not rewind before 0', function(assert) {
 
   hifi.play('/good/1000/test').then(() => {
     hifi.rewind(5000);
+    done();
+  });
+});
+
+test('it can not fast forward past duration', function(assert) {
+  let done = assert.async();
+  let service = this.subject({});
+  let hifi = service.get('hifi');
+
+  hifi.play('/good/1000/test').then(() => {
+    hifi.fastForward(5000);
+    assert.equal(hifi.get('position'), 1000, "sound should be at the end");
     done();
   });
 });

--- a/tests/unit/services/hifi-integration-test.js
+++ b/tests/unit/services/hifi-integration-test.js
@@ -97,3 +97,33 @@ test('it simulates play', function(assert) {
     }, (tickInterval * (ticks + 1)))
   });
 });
+
+test('it can not rewind before 0', function(assert) {
+  let done = assert.async();
+  let service = this.subject({});
+  let hifi = service.get('hifi');
+
+  hifi.one('audio-will-rewind', (sound, {newPosition}) => {
+    assert.equal(newPosition, 0, "sound should be at the end");
+  });
+
+  hifi.play('/good/1000/test').then(() => {
+    hifi.rewind(5000);
+    done();
+  });
+});
+
+test('it sends an audio-ended event when the sound ends',function(assert) {
+  let done = assert.async();
+  let service = this.subject({});
+  let hifi = service.get('hifi');
+
+  hifi.one('audio-ended', (sound) => {
+    assert.equal(sound.get('position'), sound.get('duration'), "sound should be at the end");
+  });
+
+  hifi.play('/good/1000/test').then(() => {
+    hifi.set('position', 5000);
+    done();
+  })
+});

--- a/tests/unit/services/hifi-integration-test.js
+++ b/tests/unit/services/hifi-integration-test.js
@@ -86,12 +86,14 @@ test('it simulates play', function(assert) {
   let hifi = service.get('hifi');
 
   hifi.play('/good/1500/test/yes').then(({sound}) => {
+    let tickInterval = sound.get('_tickInterval');
+    let ticks = 5;
     assert.equal(sound._currentPosition(), 0, "initial position should be 0");
-
     Ember.run.later(() => {
-      assert.equal(sound._currentPosition(), 1000, "position should be 1000");
+      assert.equal(sound._currentPosition(), tickInterval * ticks, `position should be ${tickInterval * ticks}`);
       assert.equal(sound.get('isPlaying'), true, "should be playing");
       done();
-    }, 1000)
+      sound.stop();
+    }, (tickInterval * (ticks + 1)))
   });
 });

--- a/tests/unit/services/hifi-integration-test.js
+++ b/tests/unit/services/hifi-integration-test.js
@@ -1,0 +1,104 @@
+import { moduleFor, test } from 'ember-qunit';
+import sinon from 'sinon';
+import Ember from 'ember';
+import { dummyHifi, hifiNeeds } from '../../../tests/helpers/hifi-integration-helpers';
+// let audioService;
+var originalLoggerError, originalTestAdapterException;
+
+moduleFor('service:audio', 'Unit | Service | hifi integration test.js', {
+  needs: [...hifiNeeds],
+
+  beforeEach() {
+    this.register('service:hifi', dummyHifi);
+    this.inject.service('hifi')
+
+    /* disable erroneous throwing of errors for rejected promises
+     https://github.com/emberjs/ember.js/issues/11469#issuecomment-228132452 */
+
+    originalLoggerError = Ember.Logger.error;
+    originalTestAdapterException = Ember.Test.adapter.exception;
+    Ember.Logger.error = function() {};
+    Ember.Test.adapter.exception = function() {};
+  },
+  afterEach() {
+    Ember.Logger.error = originalLoggerError;
+    Ember.Test.adapter.exception = originalTestAdapterException;
+  }
+});
+
+// Replace this with your real tests.
+test('playing good url works', function(assert) {
+  let service = this.subject({})
+  service.playGood().then(({sound}) => {
+    assert.ok(sound);
+  });
+});
+
+test('playing a bad url fails', function(assert) {
+  let service = this.subject({});
+  let failures, success;
+
+  let play = service.playBad();
+
+  play.then(() => (success = true));
+  play.catch((results) => {
+    failures = results.failures;
+    assert.ok(failures && failures.length > 0, "should have reported failures");
+  });
+
+  assert.equal(!!success, false, "should not be successful")
+});
+
+test('playing a blank url fails', function(assert) {
+  let service = this.subject({});
+  let failures, results;
+
+  Ember.run(() => {
+    service.playBlank().catch(r => {
+      results = r;
+      failures = results.failures;
+    });
+
+    assert.ok(!failures, "should not be failures");
+  });
+});
+
+test('it sets fixed duration correctly', function(assert) {
+  let service = this.subject({});
+  let hifi = service.get('hifi');
+
+  hifi.load('/good/2500/test').then(({sound}) => {
+    assert.equal(sound.get('duration'), 2500);
+  });
+});
+
+test('it sets stream duration correctly', function(assert) {
+  let service = this.subject({});
+  let hifi = service.get('hifi');
+
+  hifi.load('/good/stream/test').then(({sound}) => {
+    assert.equal(sound.get('duration'), Infinity, "duration should be infinity");
+    assert.equal(sound.get('isStream'), true, "should be stream");
+  })
+});
+
+test('it simulates play', function(assert) {
+  let service = this.subject({});
+  let hifi = service.get('hifi');
+  this.clock = sinon.useFakeTimers();
+  this.clock.tick(10000);
+  hifi.play('/good/3000/test').then(({sound}) => {
+    assert.equal(sound._currentPosition(), 0, "initial position should be 0");
+    this.clock.tick(1000);
+    assert.equal(sound._currentPosition(), 1000, "position should be 2000");
+    assert.equal(sound.get('isPlaying'), true, "should be playing");
+
+    this.clock.tick(2000);
+    assert.equal(sound._currentPosition(), 3000, "position should be 2000");
+    assert.equal(sound.get('isPlaying'), false, "should not be playing");
+
+    this.clock.restore();
+  });
+  this.clock.tick(100);
+
+});

--- a/tests/unit/services/hifi-integration-test.js
+++ b/tests/unit/services/hifi-integration-test.js
@@ -119,7 +119,7 @@ test('it sends an audio-ended event when the sound ends',function(assert) {
   let hifi = service.get('hifi');
 
   hifi.one('audio-ended', (sound) => {
-    assert.equal(sound.get('position'), sound.get('duration'), "sound should be at the end");
+    assert.equal(sound.get('position'), 1000, "sound should be at the end");
   });
 
   hifi.play('/good/1000/test').then(() => {

--- a/tests/unit/services/hifi-integration-test.js
+++ b/tests/unit/services/hifi-integration-test.js
@@ -1,8 +1,6 @@
 import { moduleFor, test } from 'ember-qunit';
-import sinon from 'sinon';
 import Ember from 'ember';
 import { dummyHifi, hifiNeeds } from '../../../tests/helpers/hifi-integration-helpers';
-// let audioService;
 var originalLoggerError, originalTestAdapterException;
 
 moduleFor('service:audio', 'Unit | Service | hifi integration test.js', {
@@ -83,22 +81,18 @@ test('it sets stream duration correctly', function(assert) {
 });
 
 test('it simulates play', function(assert) {
+  let done = assert.async();
+  assert.expect(3);
   let service = this.subject({});
   let hifi = service.get('hifi');
-  this.clock = sinon.useFakeTimers();
-  this.clock.tick(10000);
-  hifi.play('/good/3000/test').then(({sound}) => {
+
+  hifi.play('/good/1500/test/yes').then(({sound}) => {
     assert.equal(sound._currentPosition(), 0, "initial position should be 0");
-    this.clock.tick(1000);
-    assert.equal(sound._currentPosition(), 1000, "position should be 2000");
-    assert.equal(sound.get('isPlaying'), true, "should be playing");
 
-    this.clock.tick(2000);
-    assert.equal(sound._currentPosition(), 3000, "position should be 2000");
-    assert.equal(sound.get('isPlaying'), false, "should not be playing");
-
-    this.clock.restore();
+    Ember.run.later(() => {
+      assert.equal(sound._currentPosition(), 1000, "position should be 1000");
+      assert.equal(sound.get('isPlaying'), true, "should be playing");
+      done();
+    }, 1000)
   });
-  this.clock.tick(100);
-
 });

--- a/tests/unit/services/hifi-integration-test.js
+++ b/tests/unit/services/hifi-integration-test.js
@@ -24,7 +24,6 @@ moduleFor('service:audio', 'Unit | Service | hifi integration test.js', {
   }
 });
 
-// Replace this with your real tests.
 test('playing good url works', function(assert) {
   let service = this.subject({})
   service.playGood().then(({sound}) => {

--- a/tests/unit/services/hifi-test.js
+++ b/tests/unit/services/hifi-test.js
@@ -118,7 +118,7 @@ test('#activateConnections activates an array of connections', function(assert) 
 
 test('it returns a list of the available connections', function(assert) {
   const service = this.subject({ options });
-  assert.deepEqual(service.availableConnections(), ["Howler", "NativeAudio", "LocalDummyConnection", "DummyConnection"]);
+  assert.deepEqual(service.availableConnections(), ["Howler", "NativeAudio", "LocalDummyConnection"]);
 });
 
 test('#load tries the first connection that says it can handle the url', function(assert) {

--- a/tests/unit/services/hifi-test.js
+++ b/tests/unit/services/hifi-test.js
@@ -841,7 +841,7 @@ test("current-sound-interrupted event gets fired when a new `play` request happe
   });
 
   return service.play(s1url).then(() => {
-    return service.play(s2url).then(() => done());
+    return service.play(s2url).then(done);
   });
 });
 

--- a/tests/unit/services/hifi-test.js
+++ b/tests/unit/services/hifi-test.js
@@ -941,3 +941,64 @@ test("new-load-request gets fired on new load requests that are cached", functio
     });
   });
 });
+
+test("audio-position-will-change gets fired on position changes", function(assert) {
+  let done        = assert.async();
+  let service     = this.subject({ options: activateDummyConnection() });
+  let s1url       = "/good/15000/test";
+
+  assert.expect(2);
+
+  service.one('audio-position-will-change', (sound, {currentPosition, newPosition}) => {
+    assert.equal(currentPosition, 0, "current position should be zero");
+    assert.equal(newPosition, 5000, "new position should be 5000");
+  });
+
+  return service.play(s1url).then(() => {
+    service.set('position', 5000);
+    done();
+  });
+});
+
+test("audio-will-rewind gets fired on rewind", function(assert) {
+  let done        = assert.async();
+  let service     = this.subject({ options: activateDummyConnection() });
+  let s1url       = "/good/15000/test2";
+
+  assert.expect(4);
+
+  service.one('audio-will-rewind', (sound, {currentPosition, newPosition}) => {
+    assert.equal(currentPosition, 5000, "current position should be zero");
+    assert.equal(newPosition, 4000, "new position should be 5000");
+  });
+
+  return service.play(s1url, {position: 5000}).then(() => {
+    service.rewind(1000);
+
+    service.on('audio-will-rewind', (sound, {currentPosition, newPosition}) => {
+      assert.equal(currentPosition, 4000, "current position should be zero");
+      assert.equal(newPosition, 0, "new position should be 5000");
+    });
+
+    service.rewind(6000);
+    done();
+  });
+});
+
+test("audio-will-fast-forward gets fired on fast forward", function(assert) {
+  let done        = assert.async();
+  let service     = this.subject({ options: activateDummyConnection() });
+  let s1url       = "/good/15000/1.mp3";
+
+  assert.expect(2);
+
+  service.on('audio-will-fast-forward', (sound, {currentPosition, newPosition}) => {
+    assert.equal(currentPosition, 5000, "current position should be zero");
+    assert.equal(newPosition, 6000, "new position should be 5000");
+  });
+
+  return service.play(s1url, {position: 5000}).then(() => {
+    service.fastForward(1000);
+    done();
+  });
+});

--- a/tests/unit/services/hifi-test.js
+++ b/tests/unit/services/hifi-test.js
@@ -799,7 +799,7 @@ test("service triggers `current-sound-changed` event when sounds change", functi
       assert.equal(previousSound.get('url'), "/assets/silence.mp3", "previous sound should be this sound");
       assert.equal(currentSound.get('url'), "/assets/silence2.mp3");
     });
-    return service.play(s2url).then(() => done());
+    return service.play(s2url).then(done);
   });
 });
 
@@ -933,7 +933,7 @@ test("new-load-request gets fired on new load requests that are cached", functio
   return service.load(s1url, {metadata: {id: 1}}).then(() => {
     service.one('new-load-request', ({urlsOrPromise, options}) => {
       assert.equal(urlsOrPromise, s1url, "url should equal url passed in");
-      assert.equal(options.metadata.id, 2, "metadata id should be undefined");
+      assert.equal(options.metadata.id, 2, "metadata id should be 2");
     });
 
     return service.load(s1url, {metadata: {id: 2}}).then(() => {
@@ -968,16 +968,16 @@ test("audio-will-rewind gets fired on rewind", function(assert) {
   assert.expect(4);
 
   service.one('audio-will-rewind', (sound, {currentPosition, newPosition}) => {
-    assert.equal(currentPosition, 5000, "current position should be zero");
-    assert.equal(newPosition, 4000, "new position should be 5000");
+    assert.equal(currentPosition, 5000, "current position should be 5000");
+    assert.equal(newPosition, 4000, "new position should be 4000");
   });
 
   return service.play(s1url, {position: 5000}).then(() => {
     service.rewind(1000);
 
     service.on('audio-will-rewind', (sound, {currentPosition, newPosition}) => {
-      assert.equal(currentPosition, 4000, "current position should be zero");
-      assert.equal(newPosition, 0, "new position should be 5000");
+      assert.equal(currentPosition, 4000, "current position should be 4000");
+      assert.equal(newPosition, 0, "new position should be 0");
     });
 
     service.rewind(6000);
@@ -993,8 +993,8 @@ test("audio-will-fast-forward gets fired on fast forward", function(assert) {
   assert.expect(2);
 
   service.on('audio-will-fast-forward', (sound, {currentPosition, newPosition}) => {
-    assert.equal(currentPosition, 5000, "current position should be zero");
-    assert.equal(newPosition, 6000, "new position should be 5000");
+    assert.equal(currentPosition, 5000, "current position should be 5000");
+    assert.equal(newPosition, 6000, "new position should be 6000");
   });
 
   return service.play(s1url, {position: 5000}).then(() => {


### PR DESCRIPTION
Changes: 

1. Improved `dummyConnection` and added `hifi-integration-helpers`, and a new test within hifi that tests integrating hifi into another service (and some of this new dummy logic)
2. I added a `current-sound-interrupted` event. 

Re: #1: Testing the hifi service in other other services was getting to be really painful, so I made a `dummyHifi` service available to consumers. It's an improvement on the previous `dummyConnection`. Now the connection inherits from the base sound and acts like a real sound object would, but the connection responds to special urls instead of actually loading audio files. This is adequate for testing events in other services.

For instance, sending a url of `/good/30000/label` to the dummyConnection would result in a success response, producing a sound with 30000ms duration. Similarly, `/good/stream/label` produces a successful stream (with duration = Infinity). Anything starting with `/bad/*` will fail. We can expand on these conditions, but having this smarter dummy service made testing integrations in addons far easier.

Re: #2:  Trying to piecemeal some events together to detect that "track interrupted" case in the web client turned out to be really problematic. 