### PR TITLE
[Linter] Adds missing semicolon

### DIFF
--- a/addon/hifi-connections/dummy-connection.js
+++ b/addon/hifi-connections/dummy-connection.js
@@ -33,7 +33,7 @@ let DummyConnection = BaseSound.extend({
     this.tick = window.setTimeout(Ember.run.bind(() => {
       this._setPosition((this._currentPosition() || 0) + this.get('_tickInterval'));
       this.startTicking();
-    }), this.get('_tickInterval'))
+    }), this.get('_tickInterval'));
   },
 
   getInfoFromUrl: function() {


### PR DESCRIPTION
`ember-hifi/hifi-connections/dummy-connection.js: line 36, col 35, Missing semicolon.`

Makes jshint happy