### PR TITLE
adds a `pre-load` event with the currently attempted strategy

### DIFF
--- a/addon/services/hifi.js
+++ b/addon/services/hifi.js
@@ -597,6 +597,7 @@ export default Service.extend(Evented, DebugLogging, {
     this.timeStart(options.debugName, "_findFirstPlayableSound");
 
     let promise = PromiseRace.start(strategies, (strategy, returnSuccess, markAsFailure) => {
+      this.trigger('pre-load', strategy);
       let Connection         = strategy.connection;
       let connectionOptions  = getProperties(strategy, 'url', 'connectionName', 'sharedAudioAccess', 'options');
       let sound              = Connection.create(connectionOptions);


### PR DESCRIPTION
allows for users to update a given strategy's options or attributes right before hifi attempts to play it for compatibility purposes

[ticket](https://jira.wnyc.org/browse/RT-701)