### PR TITLE
WNYC-184 Trigger an event when an HLS stream's ID3 timed metadata changes

### DIFF
--- a/addon/helpers/json-stringify.js
+++ b/addon/helpers/json-stringify.js
@@ -1,0 +1,8 @@
+import { helper } from '@ember/component/helper';
+
+export default helper(function jsonStringify(params/*, hash*/) {
+  if (!params || !params[0] || params[0] == undefined) {
+    return "";
+  }
+  return JSON.stringify(params[0]);
+});

--- a/addon/hifi-connections/hls.js
+++ b/addon/hifi-connections/hls.js
@@ -26,7 +26,7 @@ let ClassMethods = Mixin.create({
 let Sound = BaseSound.extend({
   loaded: false,
   mediaRecoveryAttempts: 0,
-  id3TagMetadata: {},
+  id3TagMetadata: null,
 
   setup() {
     let hls   = new HLS({debug: false, startFragPrefetch: true});

--- a/addon/hifi-connections/hls.js
+++ b/addon/hifi-connections/hls.js
@@ -1,7 +1,6 @@
 import Mixin from '@ember/object/mixin';
 import BaseSound from './base';
 import HLS from 'hls';
-import { isEqual } from '@ember/utils';
 
 let ClassMethods = Mixin.create({
   acceptMimeTypes:  ['application/vnd.apple.mpegurl'],
@@ -71,7 +70,6 @@ let Sound = BaseSound.extend({
 
         if (JSON.stringify(self.get('id3TagMetadata')) !== JSON.stringify(newId3TagMetadata)) {
           this.debug('hls metadata changed');
-          this.debug("new title: " + f.frag.title);
           this.trigger('audio-metadata-changed', this, {
             old: self.get('id3TagMetadata'),
             new: newId3TagMetadata

--- a/addon/hifi-connections/hls.js
+++ b/addon/hifi-connections/hls.js
@@ -1,6 +1,7 @@
 import Mixin from '@ember/object/mixin';
 import BaseSound from './base';
 import HLS from 'hls';
+import { isEqual } from '@ember/utils';
 
 let ClassMethods = Mixin.create({
   acceptMimeTypes:  ['application/vnd.apple.mpegurl'],
@@ -26,6 +27,7 @@ let ClassMethods = Mixin.create({
 let Sound = BaseSound.extend({
   loaded: false,
   mediaRecoveryAttempts: 0,
+  id3TagMetadata: {},
 
   setup() {
     let hls   = new HLS({debug: false, startFragPrefetch: true});
@@ -60,6 +62,23 @@ let Sound = BaseSound.extend({
       });
 
       hls.on(HLS.Events.ERROR, (e, data) => this._onHLSError(e, data));
+
+      var self = this;
+      hls.on(HLS.Events.FRAG_CHANGED, (e, f) => {
+        let newId3TagMetadata = {
+          title: f.frag.title
+        }
+
+        if (JSON.stringify(self.get('id3TagMetadata')) !== JSON.stringify(newId3TagMetadata)) {
+          this.debug('hls metadata changed');
+          this.debug("new title: " + f.frag.title);
+          this.trigger('audio-metadata-changed', this, {
+            old: self.get('id3TagMetadata'),
+            new: newId3TagMetadata
+          });
+          self.set('id3TagMetadata', newId3TagMetadata);
+        }
+      });
     });
   },
 

--- a/addon/services/hifi.js
+++ b/addon/services/hifi.js
@@ -33,7 +33,8 @@ export const EVENT_MAP = [
   {event: 'audio-loading',              handler: '_relayLoadingEvent'},
   {event: 'audio-position-will-change', handler: '_relayPositionWillChangeEvent'},
   {event: 'audio-will-rewind',          handler: '_relayWillRewindEvent'},
-  {event: 'audio-will-fast-forward',    handler: '_relayWillFastForwardEvent'}
+  {event: 'audio-will-fast-forward',    handler: '_relayWillFastForwardEvent'},
+  {event: 'audio-metadata-changed', handler: '_relayMetadataChangedEvent'}
 ]
 
 export const SERVICE_EVENT_MAP = [
@@ -86,6 +87,7 @@ export default Service.extend(Evented, DebugLogging, {
   duration:          readOnly('currentSound.duration'),
   percentLoaded:     readOnly('currentSound.percentLoaded'),
   pollInterval:      reads('options.emberHifi.positionInterval'),
+  id3TagMetadata:    reads('currentSound.id3TagMetadata'),
 
   defaultVolume: 50,
 
@@ -497,6 +499,9 @@ export default Service.extend(Evented, DebugLogging, {
   },
   _relayWillFastForwardEvent(sound, info) {
     this._relayEvent('audio-will-fast-forward', sound, info);
+  },
+  _relayMetadataChangedEvent(sound, info) {
+    this._relayEvent('audio-metadata-changed', sound, info);
   },
   /**
    * Activates the connections as specified in the config options

--- a/addon/services/hifi.js
+++ b/addon/services/hifi.js
@@ -34,7 +34,7 @@ export const EVENT_MAP = [
   {event: 'audio-position-will-change', handler: '_relayPositionWillChangeEvent'},
   {event: 'audio-will-rewind',          handler: '_relayWillRewindEvent'},
   {event: 'audio-will-fast-forward',    handler: '_relayWillFastForwardEvent'},
-  {event: 'audio-metadata-changed', handler: '_relayMetadataChangedEvent'}
+  {event: 'audio-metadata-changed',     handler: '_relayMetadataChangedEvent'}
 ]
 
 export const SERVICE_EVENT_MAP = [

--- a/app/helpers/json-stringify.js
+++ b/app/helpers/json-stringify.js
@@ -1,0 +1,1 @@
+export { default, jsonStringify } from 'ember-hifi/helpers/json-stringify';

--- a/tests/dummy/app/components/sound-display/template.hbs
+++ b/tests/dummy/app/components/sound-display/template.hbs
@@ -92,6 +92,9 @@
 
     <dt>percentLoaded</dt>
     <dd>{{sound.percentLoaded}}</dd>
+
+    <dt>id3TagMetadata</dt>
+    <dd>{{json-stringify sound.id3TagMetadata}}</dd>
   </dl>
 
   <h3>Strategy</h3>

--- a/tests/integration/helpers/json-stringify-test.js
+++ b/tests/integration/helpers/json-stringify-test.js
@@ -1,0 +1,38 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | json-stringify', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    this.set('inputValue', { title: 'Morning Edition'});
+
+    await render(hbs`{{json-stringify inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), '{"title":"Morning Edition"}');
+  });
+
+  test('a null input returns an empty string', async function(assert) {
+    this.set('inputValue', null);
+
+    await render(hbs`{{json-stringify inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+  });
+
+  test('an undefined/null input returns an empty string', async function(assert) {
+    this.set('inputValue', undefined);
+
+    await render(hbs`{{json-stringify inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    this.set('inputValue', null);
+
+    await render(hbs`{{json-stringify inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+  });
+});


### PR DESCRIPTION
This PR adds code to record id3 tag timed metadata emitted from an HLS stream and notify consuming clients when the metadata changes. Currently, the title (`TIT2`) tag is recorded because it fits our specific use case, but I plan to revisit this and add more tags.